### PR TITLE
Fix path of url

### DIFF
--- a/class-locale.php
+++ b/class-locale.php
@@ -252,11 +252,11 @@ class Babble_Locale {
 	 **/
 	public function home_url( $url, $path ) {
 		$base_url = get_option( 'home' );
-		$path = ltrim( $path, '/' );
-		$url = trailingslashit( $base_url ) . $this->url_prefix;
-		if ( !empty( $path ) and ( '/' != $path ) )
-			$url .= '/';
-		$url .= $path;
+		$url      = trailingslashit( $base_url ) . $this->url_prefix;
+
+		if ( $path && is_string( $path ) )
+			$url .= '/' . ltrim( $path, '/' );
+
 		return $url;
 	}
 


### PR DESCRIPTION
Shouldn't it be more like http://core.trac.wordpress.org/browser/tags/3.6/wp-includes/link-template.php#L1904.

Currently it would break multisite and scheme support.
