### PR TITLE
Load pre_get_posts later and if there is a post type provided then set it to that one

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -104,7 +104,7 @@ class Babble_Post_Public extends Babble_Plugin {
 		$this->add_action( 'manage_posts_custom_column', 'manage_posts_custom_column', null, 2 );
 		$this->add_action( 'parse_request' );
 		$this->add_action( 'post_updated' );
-		$this->add_action( 'pre_get_posts', null, null, 11 );
+		$this->add_action( 'pre_get_posts', null, 11 );
 		$this->add_action( 'registered_post_type', null, null, 2 );
 		$this->add_action( 'save_post', null, null, 2 );
 		$this->add_action( 'transition_post_status', null, null, 3 );


### PR DESCRIPTION
In my case I provided the post type through search /?s=&post_type=my_cpt. Before this fix it would use the post type 'post' instead of my CPT
