### PR TITLE
Add a check to be sure we don't check the same capability in user_has_cap. Fixed #154

### DIFF
--- a/class-jobs.php
+++ b/class-jobs.php
@@ -273,6 +273,11 @@ class Babble_Jobs extends Babble_Plugin {
 				# Cycle through post types with show_ui true, give edit_bbl_jobs cap to the user if they can edit any of the post types
 
 				foreach ( get_post_types( array( 'show_ui' => true ), 'objects' ) as $pto ) {
+					// Don't check the capability we already checked.
+					if ( $args[0] == $pto->cap->edit_posts ) {
+						continue;
+					}
+
 					if ( user_can( $user, $pto->cap->edit_posts ) ) {
 						$user_caps[$args[0]] = true;
 						break;


### PR DESCRIPTION
This fix stops having endless loops when you are a role like subscriber what doesn't have the ability to edit translation jobs. See #154
