### PR TITLE
Fix search query

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -1062,7 +1062,7 @@ class Babble_Post_Public extends Babble_Plugin {
 
 			// Trigger the archive listing for the relevant shadow post type
 			// of 'post' for this language.
-			if ( bbl_get_default_lang_code() != $lang ) {
+			if ( bbl_get_default_lang_code() != $lang && empty( $query_vars['s'] ) ) {
 				$post_type = isset( $query_vars[ 'post_type' ] ) ? $query_vars[ 'post_type' ] : 'post';
 
 				$query_vars[ 'post_type' ] = $this->get_post_type_in_lang( $post_type, bbl_get_current_lang_code() );


### PR DESCRIPTION
Currently on the main language it shows all posts and on the other languages only posts.
I changed this by setting exclude_from_search on all other post types. Also I had to make an exception to not set the post type on the search page.
