### PR TITLE
Fix link to view translation jobs

### DIFF
--- a/api.php
+++ b/api.php
@@ -233,9 +233,9 @@ function bbl_get_post_translations( $post ) {
  * @return array Either an array keyed by the site languages, each key containing a WP Post object
  * @access public
  **/
-function bbl_get_post_jobs( $post ) {
+function bbl_get_incomplete_post_jobs( $post ) {
 	global $bbl_jobs;
-	return $bbl_jobs->get_post_jobs( $post );
+	return $bbl_jobs->get_incomplete_post_jobs( $post );
 }
 
 /**

--- a/class-jobs.php
+++ b/class-jobs.php
@@ -746,6 +746,7 @@ class Babble_Jobs extends Babble_Plugin {
 
 		$trans   = bbl_get_post_translations( $post );
 		$incomplete_jobs    = $this->get_incomplete_post_jobs( $post );
+		$completed_jobs    = $this->get_completed_post_jobs( $post );
 		$default = bbl_get_default_lang_code();
 
 		# The ability to create a translation of a post directly
@@ -756,14 +757,14 @@ class Babble_Jobs extends Babble_Plugin {
 
 		if ( !empty( $trans ) ) {
 
-			if ( !empty( $incomplete_jobs ) and $capable ) {
+			if ( !empty( $completed_jobs ) and $capable ) {
 				?><h4><?php _e( 'Complete:', 'babble' ); ?></h4><?php
 			}
 
-			foreach ( $trans as $lang_code => $translation ) {
+			foreach ( $completed_jobs as $lang_code => $job ) {
 				$lang = bbl_get_lang( $lang_code );
 				?>
-				<p><?php printf( '%s: <a href="%s">%s</a>', $lang->display_name, get_edit_post_link( $translation->ID ), __( 'View', 'babble' ) ); ?>
+				<p><?php printf( '%s: <a href="%s">%s</a>', $lang->display_name, get_edit_post_link( $job->ID ), __( 'View', 'babble' ) ); ?>
 				<?php
 			}
 
@@ -819,6 +820,18 @@ class Babble_Jobs extends Babble_Plugin {
 	public function get_incomplete_post_jobs( $post ) {
 		$post = get_post( $post );
 		return $this->get_object_jobs( $post->ID, 'post', $post->post_type, array( 'new', 'in-progress' ) );
+	}
+
+	/**
+	 * Return the array of completed jobs for a Post, keyed
+	 * by lang code.
+	 *
+	 * @param WP_Post|int $post A WP Post object or a post ID
+	 * @return array An array of WP Translation Job Post objects 
+	 */
+	public function get_completed_post_jobs( $post ) {
+		$post = get_post( $post );
+		return $this->get_object_jobs( $post->ID, 'post', $post->post_type, array( 'complete' ) );
 	}
 
 	/**

--- a/class-jobs.php
+++ b/class-jobs.php
@@ -26,31 +26,31 @@ class Babble_Jobs extends Babble_Plugin {
 	public function __construct() {
 		$this->setup( 'babble-job', 'plugin' );
 		
-		$this->add_action( 'init', 'init_early', 0 );
-		$this->add_action( 'admin_init' );
-		$this->add_action( 'edit_form_after_title' );
 		$this->add_action( 'add_meta_boxes' );
-		$this->add_action( 'bbl_translation_post_meta_boxes', null, 10, 3 );
-		$this->add_action( 'bbl_translation_terms_meta_boxes', null, 10, 2 );
-		$this->add_action( 'bbl_translation_submit_meta_boxes', null, 10, 2 );
-		$this->add_action( 'save_post', null, null, 2 );
-		$this->add_action( 'save_post', 'save_job', null, 2 );
-		$this->add_action( 'manage_bbl_job_posts_custom_column', 'action_column', null, 2 );
 		$this->add_action( 'add_meta_boxes_bbl_job', null, 999 );
-		$this->add_action( 'load-post.php', 'load_post_edit' );
-		$this->add_action( 'pre_get_posts' );
+		$this->add_action( 'admin_init' );
 		$this->add_action( 'admin_menu' );
+		$this->add_action( 'bbl_translation_post_meta_boxes', null, 10, 3 );
+		$this->add_action( 'bbl_translation_submit_meta_boxes', null, 10, 2 );
+		$this->add_action( 'bbl_translation_terms_meta_boxes', null, 10, 2 );
+		$this->add_action( 'edit_form_after_title' );
+		$this->add_action( 'init', 'init_early', 0 );
+		$this->add_action( 'load-post.php', 'load_post_edit' );
+		$this->add_action( 'manage_bbl_job_posts_custom_column', 'action_column', null, 2 );
+		$this->add_action( 'pre_get_posts' );
+		$this->add_action( 'save_post', 'save_job', null, 2 );
+		$this->add_action( 'save_post', null, null, 2 );
 		$this->add_action( 'wp_before_admin_bar_render' );
 
-		$this->add_filter( 'manage_bbl_job_posts_columns', 'filter_columns' );
+		$this->add_filter( 'admin_title', null, null, 2 );
 		$this->add_filter( 'bbl_translated_post_type', null, null, 2 );
 		$this->add_filter( 'bbl_translated_taxonomy', null, null, 2 );
 		$this->add_filter( 'get_edit_post_link', null, null, 3 );
+		$this->add_filter( 'manage_bbl_job_posts_columns', 'filter_columns' );
 		$this->add_filter( 'post_updated_messages' );
-		$this->add_filter( 'wp_insert_post_empty_content', null, null, 2 );
-		$this->add_filter( 'admin_title', null, null, 2 );
 		$this->add_filter( 'query_vars' );
 		$this->add_filter( 'user_has_cap', null, null, 3 );
+		$this->add_filter( 'wp_insert_post_empty_content', null, null, 2 );
 
 		$this->version = 1.1;
 	}

--- a/class-switcher-content.php
+++ b/class-switcher-content.php
@@ -90,10 +90,10 @@ class Babble_Switcher_Menu {
 
 		if ( is_singular() || is_single() || $editing_post ) {
 			$this->translations = bbl_get_post_translations( get_the_ID() );
-			$this->jobs         = bbl_get_post_jobs( get_the_ID() );
+			$this->jobs         = bbl_get_incomplete_post_jobs( get_the_ID() );
 		} else if ( 'page' == get_option( 'show_on_front' ) && is_home() ) {
 			$this->translations = bbl_get_post_translations( get_option( 'page_for_posts' ) );
-			$this->jobs         = bbl_get_post_jobs( get_option( 'page_for_posts' ) );
+			$this->jobs         = bbl_get_incomplete_post_jobs( get_option( 'page_for_posts' ) );
 		} else if ( ( !is_admin() and ( is_tax() || is_category() ) ) || $editing_term ) {
 			if ( isset( $_REQUEST[ 'tag_ID' ] ) )
 				$term = get_term( (int) @ $_REQUEST[ 'tag_ID' ], $this->screen->taxonomy );


### PR DESCRIPTION
Fixes #163 

Adds `get_completed_post_jobs`. Renames `get_post_jobs` to `get_incomplete_post_jobs`.
