### PR TITLE
Fix wrong posttype

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -1291,7 +1291,7 @@ class Babble_Post_Public extends Babble_Plugin {
 
 		// Return the original post type if we couldn't find it in our array
 		if ( ! isset( $this->lang_map2[ $lang_code ][ $base_post_type ] ) ) {
-			return $post_type;;
+			return $post_type;
 		}
 
 		return $this->lang_map2[ $lang_code ][ $base_post_type ];


### PR DESCRIPTION
The `get_post_type_in_lang()` method can return a boolean instead of a post type but the return value is always use to set the post type. When a post type like **nav_menu_item** is called it can't be found in `$this->lang_map2` which results that `get_post_type_in_lang()` returns false which mean in `WP_Query` that the post type is post and not **nav_menu_item**.

Also replaced `apply_filters( 'bbl_translated_post_type', true, $post_type )` to `bbl_is_translated_post_type()` which is exactly the same.
