### PR TITLE
Fix a PHP notice when translation term does not exist

### DIFF
--- a/templates-admin/translation-editor-terms.php
+++ b/templates-admin/translation-editor-terms.php
@@ -11,7 +11,7 @@
 
 			<h4><?php _e( 'Name', 'babble' ); ?></h4>
 			<div class="bbl-translation-property bbl-translation-property-term_name">
-				<input type="text" class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][name]" value="<?php echo esc_attr( $translation->name ); ?>">
+				<input type="text" class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][name]" value="<?php echo ! empty( $translation->name ) ? esc_attr( $translation->name ) : ''; ?>">
 			</div>
 			<div class="bbl-translation-original bbl-translation-original-term_name">
 				<?php echo esc_html( $original->name ); ?>
@@ -19,12 +19,12 @@
 
 		</div>
 
-		<?php if ( !empty( $original->slug ) or !empty( $translation->slug ) ) { ?>
+		<?php if ( ! empty( $original->slug ) or ! empty( $translation->slug ) ) { ?>
 			<div class="bbl-translation-section">
 
 				<h4><?php _e( 'Slug (optional)', 'babble' ); ?></h4>
 				<div class="bbl-translation-property bbl-translation-property-term_slug">
-					<input type="text" class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][slug]" value="<?php echo esc_attr( $translation->slug ); ?>">
+					<input type="text" class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][slug]" value="<?php echo ( ! empty( $translation->slug ) ) ? esc_attr( $translation->slug ) : ''; ?>">
 				</div>
 				<div class="bbl-translation-original bbl-translation-original-term_slug">
 					<?php echo esc_html( $original->slug ); ?>
@@ -33,12 +33,12 @@
 			</div>
 		<?php } ?>
 
-		<?php if ( !empty( $original->description ) or !empty( $translation->description ) ) { ?>
+		<?php if ( ! empty( $original->description ) or ! empty( $translation->description ) ) { ?>
 			<div class="bbl-translation-section">
 
 				<h4><?php _e( 'Description', 'babble' ); ?></h4>
 				<div class="bbl-translation-property bbl-translation-property-term_description">
-					<textarea class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][description]"><?php echo esc_textarea( $translation->description ); ?></textarea>
+					<textarea class="regular-text" name="bbl_translation[terms][<?php echo $original->term_id; ?>][description]"><?php echo ( ! empty( $translation->description ) ) ? esc_textarea( $translation->description ) : ''; ?></textarea>
 				</div>
 				<div class="bbl-translation-original bbl-translation-original-term_description">
 					<textarea class="regular-text" readonly><?php echo esc_textarea( $original->description ); ?></textarea>


### PR DESCRIPTION
The translation term does not always exist, so we need to check first before echoing a property.
