### PR TITLE
Renamed get_query_template() type to 'bbl-single'.

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -946,7 +946,7 @@ class Babble_Post_Public extends Babble_Plugin {
 
 		$templates[] = "single-{$this->get_base_post_type($post->post_type)}.php";
 		$templates[] = "single.php";
-		$template = get_query_template( 'single-posts', $templates );
+		$template = get_query_template( 'bbl-single', $templates );
 
 		return $template;
 	}


### PR DESCRIPTION
It's not WordPress name so we should rename it with a Babble prefix.
