### PR TITLE
Fix registration of 'term_translation' taxonomy.

### DIFF
--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -68,10 +68,10 @@ class Babble_Taxonomies extends Babble_Plugin {
 	 **/
 	public function init_early() {
 		// This translation will connect each term with it's translated equivalents
-		register_taxonomy( 'term_translation', 'term', array(
+		register_taxonomy( 'term_translation', null, array(
 			'rewrite' => false,
-			'public' => true,  # ?
-			'show_ui' => true, # ?
+			'public' => false,
+			'show_ui' => false,
 			'show_in_nav_menus' => false,
 			'label' => __( 'Term Translation ID', 'babble' ),
 		) );


### PR DESCRIPTION
This will cause issues with plugins like JSON REST API which tries to read the post type objects from a taxonomy. Also since it's not connected to a post type we can easily hide it from public and UI.
