### PR TITLE
Return the language of a post and other translations of it. See #184.

### DIFF
--- a/babble.php
+++ b/babble.php
@@ -72,5 +72,6 @@ require_once 'class-switcher-interface.php';
 require_once 'class-admin-bar.php';
 require_once 'class-translator.php';
 require_once 'class-updates.php';
+require_once 'class-json-rest-api.php';
 
 require_once 'miscellaneous.php';

--- a/class-json-rest-api.php
+++ b/class-json-rest-api.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class for handling support for JSON REST API
+ *
+ * @package Babble
+ * @since 1.5
+ */
+class Babble_WP_JSON extends Babble_Plugin {
+
+	public function __construct() {
+		$this->add_filter( 'json_prepare_post', null, 10, 3 );
+	}
+
+	public function json_prepare_post( $_post, $post, $context ) {
+		if ( bbl_is_translated_post_type( $post['post_type'] ) ) {
+			$lang = bbl_get_post_lang_code( (object) $post );
+
+			$posts = bbl_get_post_translations( $post );
+			unset( $posts[ $lang ] );
+
+			$_post['meta']['language'] = $lang;
+			$_post['meta']['links']['translations'] = array();
+
+			foreach ( $posts as $locale => $post_data ) {
+				$_post['meta']['links']['translations'][ $locale ] = json_url( '/posts/' . $post_data->ID );
+			}
+		}
+
+		return $_post;
+	}
+
+}
+
+global $bbl_wp_json;
+$bbl_wp_json = new Babble_WP_JSON();


### PR DESCRIPTION
As a start to build support for JSON REST API I added code that returns the language of the post and all translations of it. Unsure of those posts shouldn't be read only or linked to the translation job.
