### PR TITLE
Use wp_basename() to set $terms value in parse_request hook.

### DIFF
--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -413,7 +413,7 @@ class Babble_Taxonomies extends Babble_Plugin {
 			unset( $wp->query_vars[ 'tag' ] );
 		} else if ( isset( $wp->query_vars[ 'category_name' ] ) ) {
 			$taxonomy = $this->get_taxonomy_in_lang( 'category', $wp->query_vars[ 'lang' ] );
-			$terms = $wp->query_vars[ 'category_name' ];
+			$terms = wp_basename( $wp->query_vars[ 'category_name' ] );
 			unset( $wp->query_vars[ 'category_name' ] );
 		} else {
 			$taxonomies = array();


### PR DESCRIPTION
This fixes let urls as /en/category/parent/child/ work. $terms should get the value of `child` and not `parent/child`. This is also how WordPress internally does it.
