### PR TITLE
Add basic language install logic

### DIFF
--- a/templates-admin/options-available-languages.php
+++ b/templates-admin/options-available-languages.php
@@ -95,6 +95,18 @@
 	</tbody>
 </table>
 
+<?php if ( $installable_langs ) { ?>
+	<p>
+		<label for="add_lang"><?php esc_html_e( 'Add New Language', 'babble' ); ?></label>
+		<select name="add_lang">
+			<option disabled="disabled" selected="selected"><?php esc_html_e( 'Select Language', 'babble' ); ?></option>
+			<?php foreach ( $installable_langs as $lang ) { ?>
+				<option value="<?php echo esc_attr( $lang['language'] ); ?>"><?php echo esc_html( $lang['native_name'] ); ?></option>
+			<?php } ?>
+		</select>
+	</p>
+<?php } ?>
+
 <?php submit_button( __( 'Save Changes', 'babble' ) ); ?>
 
 </form>


### PR DESCRIPTION
This adds a little rough on the edges support for installing languages. Attempts to fix #176
Some things worth considering:
- Needs Fix: The plugin’s `is_rtl` method depends on a {language_code}.php file to be present in the languages folder. In that file it looks for a variable defining the text direction. Translations downloaded via the translations api don’t include this file. The only place I found the plugin’s text direction information being used is in the body class filter. This filter could either be adapted to use the WordPress text direction ‘detection’ or be removed completely, as a body class is set when the text direction is rtl,
- Currently the user can only add languages available via the WordPress translation api (Or manually by adding translation files to the `languages` directory). Adding a language without a translation file present would be useful. Eg. I might want to have the admin just in English, but the front end in English, Dutch and German, whose translations would be covered by the Theme’s translation file.
