### PR TITLE
Example plugin: publish prior to translation

### DIFF
--- a/translation-fields.php
+++ b/translation-fields.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Babble Translation Fields
+Plugin Name: Babble: Translation Fields
 Plugin URI:  http://babbleplugin.com/
 Description: Support for translating meta fields in various popular plugins.
 Version:     1.0

--- a/translation-show-pre-translation.php
+++ b/translation-show-pre-translation.php
@@ -1,0 +1,29 @@
+<?php
+/*
+Plugin Name: Babble: Publish Prior to Translation
+Plugin URI:  http://babbleplugin.com/
+Description: When a post is queued for translation, immediately show the default language content while awaiting translation
+Version:     1.0
+Author:      Automattic
+Author URI:  https://automattic.com/
+Text Domain: babble
+Domain Path: /languages/
+License:     GPL v2 or later
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*/
+
+add_action( 'bbl_create_empty_translation', '__return_true' );


### PR DESCRIPTION
This plugin shows how to use the `bbl_create_empty_translation` filter to specify that, when a post is "ready for translation", empty posts will be created for each of the languages. These empty posts mean that Babble will fall back to using the content from the default/canonical language.

For example: if a Babble enabled site has French as the canonical language, and German and Russian as other languages, then when you publish a post and specify it is "ready for translation" that post will appear in the Russian and German post listings, but with the English content.
