### PR TITLE
Merge to Master – Set the flag correctly to re-allow updates to meta

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -437,7 +437,7 @@ class Babble_Post_Public extends Babble_Plugin {
 			update_post_meta( $translation->ID, $meta_key, $meta_value );
 		}
 
-		$this->updated_post_meta = false;
+		$this->no_meta_recursion = false;
 	}
 
 	/**


### PR DESCRIPTION
Post Public, meta: Set the flag correctly to re-allow updates to meta

Addresses #261 
