### PR TITLE
Rewrite rule tests and changes

### DIFF
--- a/class-languages.php
+++ b/class-languages.php
@@ -180,17 +180,6 @@ class Babble_Languages extends Babble_Plugin {
 	// PUBLIC METHODS
 	// ==============
 
-	/**
-	 * Set the active language objects for the current site, keyed
-	 * by URL prefix.
-	 * 
-	 * @return array An array of Babble language objects
-	 **/
-	public function set_active_langs( $lang_codes ) {
-		$this->parse_available_languages();
-		$this->active_langs = $lang_codes;
-	}
-
  	/**
 	 * Return the active language objects for the current site, keyed
 	 * by URL prefix. A language object looks like:

--- a/class-locale.php
+++ b/class-locale.php
@@ -278,6 +278,15 @@ class Babble_Locale {
 			exit;
 		}
 		// Otherwise, simply set the lang for this request
+
+		if ( ! isset( $this->content_lang ) ) {
+			if ( preg_match( $this->lang_regex, $this->get_request_string(), $matches ) ) {
+				$this->set_content_lang_from_prefix( $matches[ 0 ] );
+			} else {
+				$this->set_content_lang_from_prefix( bbl_get_default_lang_url_prefix() );
+			}
+		}
+
 		$wp->query_vars[ 'lang' ] = $this->content_lang;
 		$wp->query_vars[ 'lang_url_prefix' ] = $this->url_prefix;
 	}
@@ -523,7 +532,7 @@ class Babble_Locale {
 		$req_uri_array = explode('?', $req_uri);
 		$req_uri = $req_uri_array[0];
 		$self = $_SERVER['PHP_SELF'];
-		$home_path = parse_url(home_url());
+		$home_path = parse_url( get_option( 'home' ) );
 		if ( isset($home_path['path']) )
 			$home_path = $home_path['path'];
 		else

--- a/class-locale.php
+++ b/class-locale.php
@@ -21,14 +21,14 @@ class Babble_Locale {
 	 *
 	 * @var string
 	 **/
-	protected $content_lang;
+	public $content_lang;
 
 	/**
 	 * The interface language for the current request.
 	 *
 	 * @var string
 	 **/
-	protected $interface_lang;
+	public $interface_lang;
 
 	/**
 	 * The locale for the current request.

--- a/class-locale.php
+++ b/class-locale.php
@@ -82,7 +82,7 @@ class Babble_Locale {
 		add_filter( 'locale',                          array( $this, 'set_locale' ) );
 		add_filter( 'mod_rewrite_rules',               array( $this, 'mod_rewrite_rules' ) );
 		add_filter( 'post_class',                      array( $this, 'post_class' ), null, 3 );
-		add_filter( 'pre_update_option_rewrite_rules', array( $this, 'internal_rewrite_rules_filter' ) );
+		add_filter( 'rewrite_rules_array',             array( $this, 'filter_rewrite_rules_array' ), 999 );
 		add_filter( 'query_vars',                      array( $this, 'query_vars' ) );
 	}
 
@@ -142,15 +142,15 @@ class Babble_Locale {
 	}
 	
 	/**
-	 * Hooks the WP pre_update_option_rewrite_rules filter to add 
+	 * Hooks the WP `rewrite_rules_array` filter to add 
 	 * a prefix to the URL to pick up the virtual sub-dir specifying
 	 * the language. The redirect portion can and should remain perfectly
 	 * ignorant of it though, as we change it in parse_request.
 	 * 
-	 * @param array $langs The language codes
-	 * @return array An array of language codes utilised for this site. 
+	 * @param  array $rules The rewrite rules.
+	 * @return array        The updated rewrite rules with language prefixes.
 	 **/
-	public function internal_rewrite_rules_filter( $rules ){
+	public function filter_rewrite_rules_array( array $rules ){
 		global $wp_rewrite;
 
 		// Some rules need to be at the root of the site, without a
@@ -161,6 +161,8 @@ class Babble_Locale {
 			'humans\.txt$',
 			'robots\.txt$',
 		) );
+
+		$new_rules = array();
 
 	    foreach( (array) $rules as $regex => $query ) {
 			if ( in_array( $regex, $non_translated_rewrite_rules ) ) {

--- a/class-locale.php
+++ b/class-locale.php
@@ -552,9 +552,6 @@ class Babble_Locale {
 		$pathinfo = trim($pathinfo, '/');
 		$pathinfo = preg_replace("|^$home_path|", '', $pathinfo);
 		$pathinfo = trim($pathinfo, '/');
-		$self = trim($self, '/');
-		$self = preg_replace("|^$home_path|", '', $self);
-		$self = trim($self, '/');
 
 		// The requested permalink is in $pathinfo for path info requests and
 		//  $req_uri for other requests.

--- a/class-post-public.php
+++ b/class-post-public.php
@@ -198,7 +198,7 @@ class Babble_Post_Public extends Babble_Plugin {
 		$this->set_transid( $new_post, $transid );
 
 		// Copy all the metadata across
-		$this->sync_post_meta( $new_post->ID );
+		$this->sync_post_meta( $new_post->ID, $origin_post );
 
 		// Copy the various core post properties across
 		$this->sync_properties( $origin_post->ID, $new_post->ID );
@@ -1405,10 +1405,11 @@ class Babble_Post_Public extends Babble_Plugin {
 	 * Resync all (synced) post meta data from the post in
 	 * the default language to this post.
 	 *
-	 * @param $int The post ID to sync TO
+	 * @param int         $post_id     The post ID to sync TO.
+	 * @param int|WP_Post $origin_post The post ID or object to sync FROM.
 	 * @return void
 	 **/
-	function sync_post_meta( $post_id ) {
+	function sync_post_meta( $post_id, $origin_post = null ) {
 		if ( $this->no_meta_recursion )
 			return;
 		$this->no_meta_recursion = 'updated_post_meta';
@@ -1425,7 +1426,11 @@ class Babble_Post_Public extends Babble_Plugin {
 		}
 
 		// Now add meta in again from the origin post
-		$origin_post = bbl_get_post_in_lang( $post_id, bbl_get_default_lang_code() );
+		if ( $origin_post ) {
+			$origin_post = get_post( $origin_post );
+		} else {
+			$origin_post = bbl_get_post_in_lang( $post_id, bbl_get_default_lang_code() );
+		}
 
 		$metas = get_post_meta( $origin_post->ID );
 		if ( ! $metas )

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -322,6 +322,9 @@ class Babble_Taxonomies extends Babble_Plugin {
 		$slug = $term->slug;
 		$t = get_taxonomy($base_taxonomy);
 	
+		$lang = $this->get_taxonomy_lang_code( $taxonomy );
+		bbl_switch_to_lang( $lang );
+
 		if ( empty($termlink) ) {
 			if ( 'category' == $base_taxonomy ) {
 				$termlink = '?cat=' . $term->term_id;
@@ -347,6 +350,9 @@ class Babble_Taxonomies extends Babble_Plugin {
 			}
 			$termlink = home_url( user_trailingslashit($termlink, 'category') );
 		}
+
+		bbl_restore_lang();
+
 		// STOP copying from get_term_link
 	
 		return $termlink;

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -401,13 +401,8 @@ class Babble_Taxonomies extends Babble_Plugin {
 
 		$taxonomy 	= false;
 		$terms 		= false;
-
+		$lang_code  = bbl_get_current_lang_code();
 		$taxonomies = get_taxonomies( null, 'objects' );
-		$lang_taxonomies = array();
-		foreach ( $taxonomies as $taxonomy => $tax_obj ) {
-			$tax = $this->get_taxonomy_in_lang( $taxonomy, bbl_get_current_lang_code() );
-			$lang_taxonomies[ $tax_obj->rewrite[ 'slug' ] ] = $tax;
-		}
 
 		if ( isset( $wp->query_vars[ 'tag' ] ) ) {
 			$taxonomy = $this->get_taxonomy_in_lang( 'post_tag', $wp->query_vars[ 'lang' ] );
@@ -419,6 +414,13 @@ class Babble_Taxonomies extends Babble_Plugin {
 			unset( $wp->query_vars[ 'category_name' ] );
 		} else {
 			$taxonomies = array();
+			$lang_taxonomies = array();
+
+			foreach ( $taxonomies as $taxonomy => $tax_obj ) {
+				$tax = $this->get_taxonomy_in_lang( $taxonomy, $lang_code );
+				$lang_taxonomies[ $tax_obj->rewrite[ 'slug' ] ] = $tax;
+			}
+
 			foreach ( $lang_taxonomies as $slug => $tax ) {
 				if ( isset( $wp->query_vars[ $slug ] ) ) {
 					$taxonomies[] = $tax;
@@ -504,12 +506,15 @@ class Babble_Taxonomies extends Babble_Plugin {
 						continue;
 					}
 
-					$translated_term = $this->get_term_in_lang( $_term->term_id, $taxonomy, $lang_code, false );
-					$translated_terms[] = (int) $translated_term->term_id;
+					if ( $translated_term = $this->get_term_in_lang( $_term->term_id, $taxonomy, $lang_code, false ) ) {
+						$translated_terms[] = (int) $translated_term->term_id;
+					}
 
 				}
 
-				$result = wp_set_object_terms( $translation->ID, $translated_terms, $translated_taxonomy, $append );
+				if ( $translated_terms ) {
+					$result = wp_set_object_terms( $translation->ID, $translated_terms, $translated_taxonomy, $append );
+				}
 			}
 			
 		} else {

--- a/tests/test-requests.php
+++ b/tests/test-requests.php
@@ -1,0 +1,264 @@
+<?php
+
+class Test_Requests extends Babble_UnitTestCase {
+
+	public function setUp() {
+		$this->install_languages();
+
+		parent::setUp();
+	}
+
+	public function test_home_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/en/' );
+
+		$this->assertSame( 'en_US', get_locale() );
+		$this->assertSame( 'en_US', $wp->query_vars['lang'] );
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/' );
+
+		$this->assertSame( 'fr_FR', get_locale() );
+		$this->assertSame( 'fr_FR', $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',    $wp->query_vars['lang_url_prefix'] );
+
+		$this->go_to( get_option( 'home' ) . '/uk/' );
+
+		$this->assertSame( 'en_GB', get_locale() );
+		$this->assertSame( 'en_GB', $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',    $wp->query_vars['lang_url_prefix'] );
+
+	}
+
+	public function test_permalink_requests() {
+		global $wp;
+
+		$en = $this->factory->post->create_and_get();
+		$uk = $this->create_post_translation( $en, 'en_GB' );
+		$fr = $this->create_post_translation( $en, 'fr_FR' );
+
+		$this->go_to( get_permalink( $en ) );
+
+		$this->assertSame( 'en_US',        get_locale() );
+		$this->assertSame( 'en_US',        $wp->query_vars['lang'] );
+		$this->assertSame( 'en',           $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( $en->post_name, $wp->query_vars['name'] );
+
+		$this->go_to( get_permalink( $fr ) );
+
+		$this->assertSame( 'fr_FR',        get_locale() );
+		$this->assertSame( 'fr_FR',        $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',           $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( $fr->post_name, $wp->query_vars['name'] );
+
+		$this->go_to( get_permalink( $uk ) );
+
+		$this->assertSame( 'en_GB',        get_locale() );
+		$this->assertSame( 'en_GB',        $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',           $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( $uk->post_name, $wp->query_vars['name'] );
+
+	}
+
+	public function test_archive_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/en/2003/01/24/' );
+
+		$this->assertSame( 'en_US', get_locale() );
+		$this->assertSame( 'en_US', $wp->query_vars['lang'] );
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( '2003',  $wp->query_vars['year'] );
+		$this->assertSame( '01',    $wp->query_vars['monthnum'] );
+		$this->assertSame( '24',    $wp->query_vars['day'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/1984/02/' );
+
+		$this->assertSame( 'fr_FR', get_locale() );
+		$this->assertSame( 'fr_FR', $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( '1984',  $wp->query_vars['year'] );
+		$this->assertSame( '02',    $wp->query_vars['monthnum'] );
+		$this->assertFalse( isset( $wp->query_vars['day'] ) );
+
+		$this->go_to( get_option( 'home' ) . '/uk/2000/' );
+
+		$this->assertSame( 'en_GB', get_locale() );
+		$this->assertSame( 'en_GB', $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( '2000',  $wp->query_vars['year'] );
+		$this->assertFalse( isset( $wp->query_vars['monthnum'] ) );
+		$this->assertFalse( isset( $wp->query_vars['day'] ) );
+
+	}
+
+	public function test_feed_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/en/feed/' );
+
+		$this->assertSame( 'en_US', get_locale() );
+		$this->assertSame( 'en_US', $wp->query_vars['lang'] );
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'feed',  $wp->query_vars['feed'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/feed/' );
+
+		$this->assertSame( 'fr_FR', get_locale() );
+		$this->assertSame( 'fr_FR', $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'feed',  $wp->query_vars['feed'] );
+
+		$this->go_to( get_option( 'home' ) . '/uk/feed/' );
+
+		$this->assertSame( 'en_GB', get_locale() );
+		$this->assertSame( 'en_GB', $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'feed',  $wp->query_vars['feed'] );
+
+	}
+
+	public function test_search_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/en/?s=babble' );
+
+		$this->assertSame( 'en_US',  get_locale() );
+		$this->assertSame( 'en_US',  $wp->query_vars['lang'] );
+		$this->assertSame( 'en',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'babble', $wp->query_vars['s'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/?s=babble' );
+
+		$this->assertSame( 'fr_FR',  get_locale() );
+		$this->assertSame( 'fr_FR',  $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'babble', $wp->query_vars['s'] );
+
+		$this->go_to( get_option( 'home' ) . '/uk/?s=babble' );
+
+		$this->assertSame( 'en_GB',  get_locale() );
+		$this->assertSame( 'en_GB',  $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'babble', $wp->query_vars['s'] );
+
+	}
+
+	public function test_term_requests() {
+		global $wp;
+
+		$en = $this->factory->term->create_and_get( array(
+			'taxonomy' => 'category',
+			'name'     => 'hello',
+		) );
+		$uk = $this->create_term_translation( $en, 'en_GB' );
+		$fr = $this->create_term_translation( $en, 'fr_FR' );
+
+		$this->go_to( get_term_link( $en ) );
+
+		$this->assertSame( 'en_US', get_locale() );
+		$this->assertSame( 'en_US', $wp->query_vars['lang'] );
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertEquals( array(
+			array(
+				'taxonomy' => 'category',
+				'field'    => 'slug',
+				'terms'    => 'hello',
+			),
+		), $wp->query_vars['tax_query'] );
+
+		$this->go_to( get_term_link( $fr ) );
+
+		$this->assertSame( 'fr_FR', get_locale() );
+		$this->assertSame( 'fr_FR', $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertEquals( array(
+			array(
+				'taxonomy' => 'category_fr_fr',
+				'field'    => 'slug',
+				'terms'    => 'hello-fr_fr',
+			),
+		), $wp->query_vars['tax_query'] );
+
+		$this->go_to( get_term_link( $uk ) );
+
+		$this->assertSame( 'en_GB', get_locale() );
+		$this->assertSame( 'en_GB', $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertEquals( array(
+			array(
+				'taxonomy' => 'category_en_gb',
+				'field'    => 'slug',
+				'terms'    => 'hello-en_gb',
+			),
+		), $wp->query_vars['tax_query'] );
+
+	}
+
+	public function test_author_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/en/author/admin/' );
+
+		$this->assertSame( 'en_US', get_locale() );
+		$this->assertSame( 'en_US', $wp->query_vars['lang'] );
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'admin', $wp->query_vars['author_name'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/author/admin/' );
+
+		$this->assertSame( 'fr_FR', get_locale() );
+		$this->assertSame( 'fr_FR', $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'admin', $wp->query_vars['author_name'] );
+
+		$this->go_to( get_option( 'home' ) . '/uk/author/admin/' );
+
+		$this->assertSame( 'en_GB', get_locale() );
+		$this->assertSame( 'en_GB', $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( 'admin', $wp->query_vars['author_name'] );
+
+	}
+
+	public function test_robots_txt_requests() {
+		global $wp;
+
+		$this->go_to( get_option( 'home' ) . '/robots.txt' );
+
+		$this->assertSame( 'en_US', get_locale() );
+		// $this->assertSame( 'en_US', $wp->query_vars['lang'] ); // ¯\_(ツ)_/¯
+		$this->assertSame( 'en',    $wp->query_vars['lang_url_prefix'] );
+		$this->assertSame( '1',     $wp->query_vars['robots'] );
+		$this->assertFalse( isset( $wp->query_vars['name'] ) );
+
+		$this->go_to( get_option( 'home' ) . '/en/robots.txt' );
+
+		$this->assertSame( 'en_US',  get_locale() );
+		$this->assertSame( 'en_US',  $wp->query_vars['lang'] );
+		$this->assertSame( 'en',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertFalse( isset( $wp->query_vars['robots'] ) );
+		// @TODO Why is this `pagename`, but translated QVs below use `name`?
+		//       Might be indicative of a problem somewhere.
+		$this->assertSame( 'robots.txt', $wp->query_vars['pagename'] );
+
+		$this->go_to( get_option( 'home' ) . '/fr/robots.txt' );
+
+		$this->assertSame( 'fr_FR',  get_locale() );
+		$this->assertSame( 'fr_FR',  $wp->query_vars['lang'] );
+		$this->assertSame( 'fr',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertFalse( isset( $wp->query_vars['robots'] ) );
+		$this->assertSame( 'robots.txt', $wp->query_vars['name'] );
+
+		$this->go_to( get_option( 'home' ) . '/uk/robots.txt' );
+
+		$this->assertSame( 'en_GB',  get_locale() );
+		$this->assertSame( 'en_GB',  $wp->query_vars['lang'] );
+		$this->assertSame( 'uk',     $wp->query_vars['lang_url_prefix'] );
+		$this->assertFalse( isset( $wp->query_vars['robots'] ) );
+		$this->assertSame( 'robots.txt', $wp->query_vars['name'] );
+
+	}
+
+}

--- a/tests/test-urls.php
+++ b/tests/test-urls.php
@@ -3,9 +3,9 @@
 class Test_URLs extends Babble_UnitTestCase {
 
 	public function setUp() {
-		parent::setUp();
-
 		$this->install_languages();
+
+		parent::setUp();
 	}
 
 	public function test_home_url() {


### PR DESCRIPTION
See #233.

This introduces unit test coverage for requests, and addresses issues in Babble relating to multiple requests on one page load (as happens during unit testing).

This also changes the hook used for filtering rewrite rules so we no longer use the `pre_update_option_rewrite_rules` filter.
