### PR TITLE
Cookies shouldn't use `$wpdb->prefix`

### DIFF
--- a/class-locale.php
+++ b/class-locale.php
@@ -89,11 +89,8 @@ class Babble_Locale {
 	public function plugins_loaded() {
 		global $wpdb;
 
-		# @TODO this exposes the $wpdb prefix. We should set the cookie path to the site path instead
-		# (example.com/site or site.example.com) so the cookie is only set for the current site on a multisite install
-		# @TODO actually, both of these should be user preferences, not cookies.
-		$this->content_lang_cookie   = $wpdb->prefix . '_bbl_content_lang_' . COOKIEHASH;
-		$this->interface_lang_cookie = $wpdb->prefix . '_bbl_interface_lang_' . COOKIEHASH;
+		$this->content_lang_cookie   = 'wp-bbl_content_lang_' . COOKIEHASH;
+		$this->interface_lang_cookie = 'wp-bbl_interface_lang_' . COOKIEHASH;
 	}
 
 	/**
@@ -564,12 +561,15 @@ class Babble_Locale {
 	 * as we cannot get userdata at the set_locale action, which is where 
 	 * we need to read the user's language.
 	 *
+	 * In addition, we can't use WordPress' user settings because these are stored
+	 * on a per-network basis, not on a per-blog basis.
+	 *
 	 * @return void
 	 **/
 	protected function maybe_set_cookie_content_lang() {
 		// @FIXME: At this point a mischievous XSS "attack" could set a user's content language for them
 		if ( $requested_lang = ( isset( $_GET[ 'lang' ] ) ) ? $_GET[ 'lang' ] : false )
-			setcookie( $this->content_lang_cookie, $requested_lang, time() + 31536000, COOKIEPATH, COOKIE_DOMAIN);
+			setcookie( $this->content_lang_cookie, $requested_lang, time() + 31536000, self::get_cookie_path(), COOKIE_DOMAIN);
 	}
 
 	/**
@@ -577,12 +577,29 @@ class Babble_Locale {
 	 * as we cannot get userdata at the set_locale action, which is where 
 	 * we need to read the user's language.
 	 *
+	 * In addition, we can't use WordPress' user settings because these are stored
+	 * on a per-network basis, not on a per-blog basis.
+	 *
 	 * @return void
 	 **/
 	protected function maybe_set_cookie_interface_lang() {
 		// @FIXME: At this point a mischievous XSS "attack" could set a user's admin area language for them
 		if ( $requested_lang = ( isset( $_POST[ 'interface_lang' ] ) ) ? $_POST[ 'interface_lang' ] : false )
-			setcookie( $this->interface_lang_cookie, $requested_lang, time() + 31536000, COOKIEPATH, COOKIE_DOMAIN);
+			setcookie( $this->interface_lang_cookie, $requested_lang, time() + 31536000, self::get_cookie_path(), COOKIE_DOMAIN);
+	}
+
+	/**
+	 * Return the cookie path for this blog. Babble stores some cookies on a per-blog basis, so their path needs to be
+	 * set specific to the blog. 
+	 *
+	 * @return string The cookie path for the current blog.
+	 */
+	public static function get_cookie_path() {
+		if ( is_multisite() ) {
+			return get_blog_details()->path;
+		} else {
+			return COOKIEPATH;
+		}
 	}
 
 	/**

--- a/phpunit-ms.xml
+++ b/phpunit-ms.xml
@@ -1,0 +1,31 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+	    <const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">./</directory>
+			<exclude>
+				<directory>./bin</directory>
+				<directory>./features</directory>
+				<directory>./languages</directory>
+				<directory>./node_modules</directory>
+				<directory>./svn</directory>
+				<directory>./tests</directory>
+				<directory>./vendor</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/test-cookies.php
+++ b/tests/test-cookies.php
@@ -1,0 +1,51 @@
+<?php
+
+class Test_Cookies extends Babble_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->install_languages();
+	}
+
+	public function test_single_site_cookie_path() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Test not applicable on multisite' );
+		}
+
+		$this->assertSame( '/', Babble_Locale::get_cookie_path() );
+
+	}
+
+	/**
+	 * @group multisite
+	 */
+	public function test_multisite_cookie_path() {
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on multisite' );
+		}
+
+		$this->assertSame( '/', Babble_Locale::get_cookie_path() );
+
+		$blog1 = $this->factory->blog->create_and_get();
+		$blog2 = $this->factory->blog->create_and_get();
+
+		switch_to_blog( $blog1->blog_id );
+
+		$this->assertSame( $blog1->path, Babble_Locale::get_cookie_path() );
+
+		switch_to_blog( $blog2->blog_id );
+
+		$this->assertSame( $blog2->path, Babble_Locale::get_cookie_path() );
+
+		restore_current_blog();
+		restore_current_blog();
+
+		$this->assertSame( '/', Babble_Locale::get_cookie_path() );
+
+	}
+
+
+}


### PR DESCRIPTION
See #232.

This introduces path-specificity to the content and interface language cookies, and removes the `$wpdb->prefix` prefix. Introduces tests for single site and multisite.

If you're curious about the `wp-` prefix on the cookies, see [WordPress core issue #25287](https://core.trac.wordpress.org/ticket/25287).
