### PR TITLE
Avoid blindly throwing exceptions

### DIFF
--- a/api.php
+++ b/api.php
@@ -66,7 +66,7 @@ function bbl_get_current_lang_code() {
  * Given a lang object or lang code, this checks whether the
  * language is public or not.
  *
- * @param string $lang_code A language code
+ * @param string|object $lang_code A language code or a language object
  * @return boolean True if public
  * @access public
  **/

--- a/api.php
+++ b/api.php
@@ -136,7 +136,7 @@ function bbl_get_term_jobs( $term, $taxonomy ) {
  * @param int|object $default_term The term in the default language to create a new translation for, either WP Post object or post ID
  * @param string $lang The language code
  * @param string $taxonomy The taxonomy
- * @return string The admin URL to create the new translation
+ * @return string|WP_Error The admin URL to create the new translation, a `WP_Error` object on failure
  * @access public
  **/
 function bbl_get_new_term_translation_url( $default_term, $lang, $taxonomy = null ) {

--- a/class-languages.php
+++ b/class-languages.php
@@ -215,12 +215,13 @@ class Babble_Languages extends Babble_Plugin {
 	 * Given a lang object or lang code, this checks whether the
 	 * language is public or not.
 	 * 
-	 * @param string $lang_code A language code
+	 * @param string|object $lang_code A language code or a language object
 	 * @return boolean True if public
 	 **/
 	public function is_public_lang( $lang_code ) {
-		if ( ! is_string( $lang_code ) )
-			throw new exception( 'Please provide a lang_code for the is_public_lang method.' );
+		if ( is_object( $lang_code ) and ! empty( $lang_code->lang ) ) {
+			$lang_code = $lang_code->lang;
+		}
 		return in_array( $lang_code, $this->public_langs );
 	}
 

--- a/class-languages.php
+++ b/class-languages.php
@@ -153,21 +153,37 @@ class Babble_Languages extends Babble_Plugin {
 		$langs = $this->merge_lang_sets( $this->available_langs, $this->lang_prefs );
 		// Merge in any POSTed field values
 		foreach ( $langs as $code => & $lang ) {
-			$lang->url_prefix = ( @ isset( $_POST[ 'url_prefix_' . $code ] ) ) ? $_POST[ "url_prefix_$code" ] : @ $lang->url_prefix;
-			if ( ! $lang->url_prefix )
-				$lang->url_prefix = $lang->url_prefix;
-			$lang->text_direction = $lang->text_direction;
+			if ( ! empty( $_POST[ "url_prefix_$code" ] ) ) {
+				$lang->url_prefix = $_POST[ "url_prefix_$code" ];
+			} else if ( empty( $lang->url_prefix ) ) {
+				$parts = explode( '_', $lang->code );
+				$lang->url_prefix = $parts[0];
+			}
+			if ( ! in_array( $lang->text_direction, array( 'ltr', 'rtl' ) ) ) {
+				// @TODO is this needed?
+				$lang->text_direction = 'ltr';
+			}
 			// This line must come after the text direction value is set
 			$lang->input_lang_class = ( 'rtl' == $lang->text_direction ) ? 'lang-rtl' : 'lang-ltr' ;
-			$lang->display_name = ( @ isset( $_POST[ "display_name_$code" ] ) ) ? $_POST[ "display_name_$code" ] : @ $lang->display_name;
-			if ( ! $lang->display_name )
+
+			if ( ! empty( $_POST[ "display_name_$code" ] ) ) {
+				$lang->display_name = $_POST[ "display_name_$code" ];
+			} else if ( empty( $lang->display_name ) ) {
 				$lang->display_name = $lang->name;
+			}
+
 			// Note any url_prefix errors
-			$lang->url_prefix_error = ( @ $this->errors[ "url_prefix_$code" ] ) ? 'babble-error' : '0' ;
+			if ( ! empty( $this->errors[ "url_prefix_$code" ] ) ) {
+				$lang->url_prefix_error = 'babble-error';
+			} else {
+				$lang->url_prefix_error = '0';
+			}
+
 			// Flag the active languages
 			$lang->active = false;
-			if ( in_array( $code, $this->active_langs ) )
+			if ( in_array( $code, $this->active_langs ) ) {
 				$lang->active = true;
+			}
 			
 		}
 		$vars = array();
@@ -342,8 +358,19 @@ class Babble_Languages extends Babble_Plugin {
 		$url_prefixes = array();
 		foreach ( $this->available_langs as $code => $lang ) {
 			$lang_pref = new stdClass;
-			$lang_pref->display_name = @ $_POST[ 'display_name_' . $code ];
-			$lang_pref->url_prefix = @ $_POST[ 'url_prefix_' . $code ];
+
+			if ( ! empty( $_POST[ 'display_name_' . $code ] ) ) {
+				$lang_pref->display_name = $_POST[ 'display_name_' . $code ];
+			} else {
+				$lang_pref->display_name = $lang->name;
+			}
+
+			if ( ! empty( $_POST[ 'url_prefix_' . $code ] ) ) {
+				$lang_pref->url_prefix = $_POST[ 'url_prefix_' . $code ];
+			} else {
+				$lang_pref->url_prefix = $lang->url_prefix;
+			}
+
 			// Check we don't have more than one language using the same url prefix
 			if ( array_key_exists( $lang_pref->url_prefix, $url_prefixes ) ) {
 				$lang_1 = $this->format_code_lang( $code );
@@ -363,8 +390,11 @@ class Babble_Languages extends Babble_Plugin {
 		if ( ! $this->errors ) {
 			$langs = $this->merge_lang_sets( $this->available_langs, $this->lang_prefs );
 			$active_langs = array();
-			foreach ( (array) @ $_POST[ 'active_langs' ] as $code )
-				$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+			if ( ! empty( $_POST[ 'active_langs' ] ) && is_array( $_POST[ 'active_langs' ] ) ) {
+				foreach ( $_POST[ 'active_langs' ] as $code ) {
+					$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+				}
+			}
 			if ( count( $active_langs ) < 2 ) {
 				$this->set_admin_error( __( 'You must set at least two languages as active.', 'babble' ) );
 			} else {
@@ -377,8 +407,11 @@ class Babble_Languages extends Babble_Plugin {
 				$this->set_admin_error( __( 'You must set at least your default language as public.', 'babble' ) );
 			} else {
 				$public_langs = (array) $_POST[ 'public_langs' ];
-				if ( ! in_array( @ $_POST[ 'default_lang' ], $public_langs ) )
+				if ( empty( $_POST[ 'default_lang' ] ) ) {
+					$this->set_admin_error( __( 'You must choose a default language.', 'babble' ) );
+				} else if ( ! in_array( $_POST[ 'default_lang' ], $public_langs ) ) {
 					$this->set_admin_error( __( 'You must set your default language as public.', 'babble' ) );
+				}
 			}
 		}
 		// Finish up, redirecting if we're all OK
@@ -387,7 +420,7 @@ class Babble_Languages extends Babble_Plugin {
 			$this->update_option( 'public_langs', $public_langs );
 			
 			// First the default language
-			$default_lang = @ $_POST[ 'default_lang' ];
+			$default_lang = $_POST[ 'default_lang' ];
 			$this->update_option( 'default_lang', $default_lang );
 			// Now the prefs
 			$this->update_option( 'lang_prefs', $lang_prefs );

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -108,9 +108,7 @@ class Babble_Plugin {
 	 * @return void
 	 * @author Simon Wheatley
 	 **/
-	public function setup( $name = '', $type = null ) {
-		if ( ! $name )
-			throw new exception( "Please pass the name parameter into the setup method." );
+	public function setup( $name, $type = null ) {
 		$this->name = $name;
 
 		// Attempt to handle a Windows

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -96,13 +96,6 @@ class Babble_Plugin {
 	protected $type;
 
 	/**
-	 * Note the name of the function to call when the theme is activated.
-	 *
-	 * @var string
-	 **/
-	protected $theme_activation_function;
-
-	/**
 	 * Initiate!
 	 *
 	 * @return void
@@ -115,13 +108,8 @@ class Babble_Plugin {
 		$ds = ( defined( 'DIRECTORY_SEPARATOR' ) ) ? DIRECTORY_SEPARATOR : '\\';
 		$file = str_replace( $ds, '/', __FILE__ );
 		$plugins_dir = str_replace( $ds, '/', dirname( __FILE__ ) );
-		// Setup the dir and url for this plugin/theme
-		if ( 'theme' == $type ) {
-			// This is a theme
-			$this->type = 'theme';
-			$this->dir = get_stylesheet_directory();
-			$this->url = get_stylesheet_directory_uri();
-		} elseif ( stripos( $file, $plugins_dir ) !== false || 'plugin' == $type ) {
+		// Setup the dir and url for this plugin
+		if ( stripos( $file, $plugins_dir ) !== false || 'plugin' == $type ) {
 			// This is a plugin
 			$this->type = 'plugin';
 
@@ -226,27 +214,7 @@ class Babble_Plugin {
 	function register_activation ( $pluginfile = __FILE__, $function = '' ) {
 		if ( $this->type == 'plugin' ) {
 			add_action ('activate_'.basename (dirname ($pluginfile)).'/'.basename ($pluginfile), array ($this, $function == '' ? 'activate' : $function));
-		} elseif ( $this->type == 'theme' ) {
-			$this->theme_activation_function = ( $function ) ? $function : 'activate';
-			add_action ('load-themes.php', array ( $this, 'theme_activation' ) );
 		}
-	}
-
-	/**
-	 * Hack to catch theme activation. We hook the load-themes.php action, look for the
-	 * "activated" GET param and make a big fat assumption if we find it.
-	 *
-	 * @return void
-	 * @author Simon Wheatley
-	 **/
-	public function theme_activation() {
-		$activated = (bool) @ $_GET[ 'activated' ];
-		if ( ! $activated )
-			return;
-		if ( ! $this->theme_activation_function )
-			return;
-		// Looks like the theme might just have been activated, call the registered function
-		$this->{$this->theme_activation_function}();
 	}
 
 	/**

--- a/class-switcher-content.php
+++ b/class-switcher-content.php
@@ -218,6 +218,9 @@ class Babble_Switcher_Menu {
 			$classes[] = 'bbl-add';
 			$classes[] = 'bbl-add-term';
 		}
+		if ( is_wp_error( $href ) ) {
+			return;
+		}
 		$href = apply_filters( 'bbl_switch_admin_term_link', $href, $lang, $this->translations );
 		$classes[] = "bbl-lang-$lang->code bbl-lang-$lang->url_prefix";
 		$classes[] = 'bbl-admin';
@@ -496,6 +499,9 @@ class Babble_Switcher_Menu {
 			$title = sprintf( __( 'Create for %s', 'babble' ), $lang->display_name );
 			$classes[] = 'bbl-add';
 			$classes[] = 'bbl-add-term';
+		}
+		if ( is_wp_error( $href ) ) {
+			return;
 		}
 		$href = apply_filters( 'bbl_switch_taxonomy_archive_link', $href, $lang, $this->translations );
 		$classes[] = "bbl-lang-$lang->code bbl-lang-$lang->url_prefix";

--- a/class-switcher-content.php
+++ b/class-switcher-content.php
@@ -96,7 +96,7 @@ class Babble_Switcher_Menu {
 			$this->jobs         = bbl_get_incomplete_post_jobs( get_option( 'page_for_posts' ) );
 		} else if ( ( !is_admin() and ( is_tax() || is_category() ) ) || $editing_term ) {
 			if ( isset( $_REQUEST[ 'tag_ID' ] ) )
-				$term = get_term( (int) @ $_REQUEST[ 'tag_ID' ], $this->screen->taxonomy );
+				$term = get_term( absint( $_REQUEST[ 'tag_ID' ] ), $this->screen->taxonomy );
 			else
 				$term = get_queried_object();
 			$this->translations = bbl_get_term_translations( $term->term_id, $term->taxonomy );

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -911,15 +911,15 @@ class Babble_Taxonomies extends Babble_Plugin {
 	 * belongs to.
 	 *
 	 * @param int $target_term_id The term ID to find the translation group for 
-	 * @return int The transID the target term belongs to
+	 * @return int|false The transID the target term belongs to, boolean false on failure
 	 **/
 	public function get_transid( $target_term_id ) {
-		if ( $transid = wp_cache_get( $target_term_id, 'bbl_term_transids' ) ) {
-			return $transid;
+		if ( ! $target_term_id ) {
+			return false;
 		}
 
-		if ( ! $target_term_id ) {
-			throw new exception( "Please specify a target term_id" );
+		if ( $transid = wp_cache_get( $target_term_id, 'bbl_term_transids' ) ) {
+			return $transid;
 		}
 
 		$transids = wp_get_object_terms( $target_term_id, 'term_translation', array( 'fields' => 'ids' ) );
@@ -941,11 +941,11 @@ class Babble_Taxonomies extends Babble_Plugin {
 	 *
 	 * @param int $target_term_id The term ID to set the translation group for
 	 * @param int $translation_group_id The ID of the translation group to add this 
-	 * @return int The transID the target term belongs to
+	 * @return int|false The transID the target term belongs to, false on failure
 	 **/
 	public function set_transid( $target_term_id, $transid = null ) {
 		if ( ! $target_term_id ) {
-			throw new exception( "Please specify a target term_id" );
+			return false;
 		}
 
 		if ( ! $transid ) {

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -49,7 +49,6 @@ class Babble_Taxonomies extends Babble_Plugin {
 		$this->add_action( 'init', 'init_early', 0 );
 		$this->add_action( 'parse_request' );
 		$this->add_action( 'registered_taxonomy', null, null, 3 );
-		$this->add_action( 'save_post', null, null, 2 );
 		$this->add_action( 'set_object_terms', null, null, 5 );
 		$this->add_filter( 'get_terms' );
 		$this->add_filter( 'term_link', null, null, 3 );
@@ -261,18 +260,6 @@ class Babble_Taxonomies extends Babble_Plugin {
 		}
 
 		$this->no_recursion = false;
-	}
-
-	/**
-	 * Hooks the WP save_post action to resync data
-	 * when requested.
-	 *
-	 * @param int $post_id The ID of the WP post
-	 * @param object $post The WP Post object 
-	 * @return void
-	 **/
-	public function save_post( $post_id, $post ) {
-		$this->maybe_resync_terms( $post_id, $post );
 	}
 
 	/**
@@ -966,61 +953,6 @@ class Babble_Taxonomies extends Babble_Plugin {
 		wp_cache_delete( $target_term_id, 'bbl_term_transids' );
 		
 		return $transid;
-	}
-
-	/**
-	 * Checks for the relevant POSTed field, then 
-	 * resyncs the terms.
-	 *
-	 * @param int $post_id The ID of the WP post
-	 * @param object $post The WP Post object 
-	 * @return void
-	 **/
-	protected function maybe_resync_terms( $post_id, $post ) {
-		// Check that the fields were included on the screen, we
-		// can do this by checking for the presence of the nonce.
-		$nonce = isset( $_POST[ '_bbl_metabox_resync' ] ) ? $_POST[ '_bbl_metabox_resync' ] : false;
-		
-		
-		if ( ! in_array( $post->post_status, array( 'draft', 'publish' ) ) ) {
-			return;
-		}
-		
-		if ( ! $nonce ) {
-			return;
-		}
-			
-		$posted_id = isset( $_POST[ 'post_ID' ] ) ? $_POST[ 'post_ID' ] : 0;
-		if ( $posted_id != $post_id ) {
-			return;
-		}
-		// While we're at it, let's check the nonce
-		check_admin_referer( "bbl_resync_translation-$post_id", '_bbl_metabox_resync' );
-		
-		if ( $this->no_recursion ) {
-			return;
-		}
-		$this->no_recursion = true;
-
-		$taxonomies = get_object_taxonomies( $post->post_type );
-		$origin_post = bbl_get_post_in_lang( $post_id, bbl_get_default_lang_code() );
-
-		// First dissociate all the terms from synced taxonomies from this post
-		wp_delete_object_term_relationships( $post_id, $taxonomies );
-
-		// Now associate terms from synced taxonomies in from the origin post
-		foreach ( $taxonomies as $taxonomy ) {
-			$origin_taxonomy = $taxonomy;
-			if ( $this->is_taxonomy_translated( $taxonomy ) ) {
-				$origin_taxonomy = bbl_get_taxonomy_in_lang( $taxonomy, bbl_get_default_lang_code() );
-			}
-			$term_ids = wp_get_object_terms( $origin_post->ID, $origin_taxonomy, array( 'fields' => 'ids' ) );
-			$term_ids = array_map( 'absint', $term_ids );
-			$result = wp_set_object_terms( $post_id, $term_ids, $taxonomy );
-			if ( is_wp_error( $result, true ) ) {
-				throw new exception( "Problem syncing terms: " . print_r( $terms, true ), " Error: " . print_r( $result, true ) );
-			}
-		}
 	}
 
 }

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -354,9 +354,7 @@ class Babble_Taxonomies extends Babble_Plugin {
 				continue;
 			}
 			if ( isset( $this->taxonomies[ $term->taxonomy ] ) ) {
-				if ( ! $this->get_transid( $term->term_id ) ) {
-					throw new exception( "ERROR: Translated term ID $term->term_id does not have a transid" );
-				} else {
+				if ( $this->get_transid( $term->term_id ) ) {
 					continue;
 				}
 			}

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -726,19 +726,15 @@ class Babble_Taxonomies extends Babble_Plugin {
 	 * particular language.
 	 *
 	 * @param int|object $default_term The term in the default language to create a new translation for, either WP Post object or post ID
-	 * @param string $lang The language code 
-	 * @return string The admin URL to create the new translation
+	 * @param string $lang_code The language code 
+	 * @param string $taxonomy The taxonomy name
+	 * @return string|WP_Error The admin URL to create the new translation, a `WP_Error` object on failure
 	 * @access public
 	 **/
-	public function get_new_term_translation_url( $default_term, $lang_code, $taxonomy = null ) {
-		if ( ! is_int( $default_term ) && is_null( $taxonomy ) ) {
-			throw new exception( 'get_new_term_translation_url: Cannot get term from term_id without taxonomy' );
-		}
-		if ( ! is_null( $taxonomy ) ) {
-			$default_term = get_term( $default_term, $taxonomy );
-		}
+	public function get_new_term_translation_url( $default_term, $lang_code, $taxonomy ) {
+		$default_term = get_term( $default_term, $taxonomy );
 		if ( is_wp_error( $default_term ) ) {
-			throw new exception( 'get_new_term_translation_url: Error getting term from term_id and taxonomy: ' . print_r( $default_term, true ) );
+			return $default_term;
 		}
 		$url = admin_url( 'post-new.php' );
 		$args = array( 

--- a/phpunit-ms.xml
+++ b/phpunit-ms.xml
@@ -1,0 +1,31 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+	    <const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">./</directory>
+			<exclude>
+				<directory>./bin</directory>
+				<directory>./features</directory>
+				<directory>./languages</directory>
+				<directory>./node_modules</directory>
+				<directory>./svn</directory>
+				<directory>./tests</directory>
+				<directory>./vendor</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>


### PR DESCRIPTION
See #218.

`bbl_get_new_term_translation_url ()` and `Babble_Taxonomies::get_new_term_translation_url()` now return a `WP_Error` object rather than throwing an exception (and the term links in the admin toolbar aren't built if so).

`bbl_is_public_lang()` and `Babble_Languages:: is_public_lang()` now accept a language object for the `$lang_code` parameter rather than throwing an exception.

`Babble_Plugin:: setup()` switches to a required parameter rather than throwing an exception.

`get_transid()` and `set_transid()` handle errors and cache checking more gracefully and return false (as they should) instead of throwing an exception.
