### PR TITLE
Fix error suppression

### DIFF
--- a/class-languages.php
+++ b/class-languages.php
@@ -153,21 +153,37 @@ class Babble_Languages extends Babble_Plugin {
 		$langs = $this->merge_lang_sets( $this->available_langs, $this->lang_prefs );
 		// Merge in any POSTed field values
 		foreach ( $langs as $code => & $lang ) {
-			$lang->url_prefix = ( @ isset( $_POST[ 'url_prefix_' . $code ] ) ) ? $_POST[ "url_prefix_$code" ] : @ $lang->url_prefix;
-			if ( ! $lang->url_prefix )
-				$lang->url_prefix = $lang->url_prefix;
-			$lang->text_direction = $lang->text_direction;
+			if ( ! empty( $_POST[ "url_prefix_$code" ] ) ) {
+				$lang->url_prefix = $_POST[ "url_prefix_$code" ];
+			} else if ( empty( $lang->url_prefix ) ) {
+				$parts = explode( '_', $lang->code );
+				$lang->url_prefix = $parts[0];
+			}
+			if ( ! in_array( $lang->text_direction, array( 'ltr', 'rtl' ) ) ) {
+				// @TODO is this needed?
+				$lang->text_direction = 'ltr';
+			}
 			// This line must come after the text direction value is set
 			$lang->input_lang_class = ( 'rtl' == $lang->text_direction ) ? 'lang-rtl' : 'lang-ltr' ;
-			$lang->display_name = ( @ isset( $_POST[ "display_name_$code" ] ) ) ? $_POST[ "display_name_$code" ] : @ $lang->display_name;
-			if ( ! $lang->display_name )
+
+			if ( ! empty( $_POST[ "display_name_$code" ] ) ) {
+				$lang->display_name = $_POST[ "display_name_$code" ];
+			} else if ( empty( $lang->display_name ) ) {
 				$lang->display_name = $lang->name;
+			}
+
 			// Note any url_prefix errors
-			$lang->url_prefix_error = ( @ $this->errors[ "url_prefix_$code" ] ) ? 'babble-error' : '0' ;
+			if ( ! empty( $this->errors[ "url_prefix_$code" ] ) ) {
+				$lang->url_prefix_error = 'babble-error';
+			} else {
+				$lang->url_prefix_error = '0';
+			}
+
 			// Flag the active languages
 			$lang->active = false;
-			if ( in_array( $code, $this->active_langs ) )
+			if ( in_array( $code, $this->active_langs ) ) {
 				$lang->active = true;
+			}
 			
 		}
 		$vars = array();
@@ -342,8 +358,19 @@ class Babble_Languages extends Babble_Plugin {
 		$url_prefixes = array();
 		foreach ( $this->available_langs as $code => $lang ) {
 			$lang_pref = new stdClass;
-			$lang_pref->display_name = @ $_POST[ 'display_name_' . $code ];
-			$lang_pref->url_prefix = @ $_POST[ 'url_prefix_' . $code ];
+
+			if ( ! empty( $_POST[ 'display_name_' . $code ] ) ) {
+				$lang_pref->display_name = $_POST[ 'display_name_' . $code ];
+			} else {
+				$lang_pref->display_name = $lang->name;
+			}
+
+			if ( ! empty( $_POST[ 'url_prefix_' . $code ] ) ) {
+				$lang_pref->url_prefix = $_POST[ 'url_prefix_' . $code ];
+			} else {
+				$lang_pref->url_prefix = $lang->url_prefix;
+			}
+
 			// Check we don't have more than one language using the same url prefix
 			if ( array_key_exists( $lang_pref->url_prefix, $url_prefixes ) ) {
 				$lang_1 = $this->format_code_lang( $code );
@@ -363,8 +390,11 @@ class Babble_Languages extends Babble_Plugin {
 		if ( ! $this->errors ) {
 			$langs = $this->merge_lang_sets( $this->available_langs, $this->lang_prefs );
 			$active_langs = array();
-			foreach ( (array) @ $_POST[ 'active_langs' ] as $code )
-				$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+			if ( ! empty( $_POST[ 'active_langs' ] ) && is_array( $_POST[ 'active_langs' ] ) ) {
+				foreach ( $_POST[ 'active_langs' ] as $code ) {
+					$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+				}
+			}
 			if ( count( $active_langs ) < 2 ) {
 				$this->set_admin_error( __( 'You must set at least two languages as active.', 'babble' ) );
 			} else {
@@ -377,8 +407,11 @@ class Babble_Languages extends Babble_Plugin {
 				$this->set_admin_error( __( 'You must set at least your default language as public.', 'babble' ) );
 			} else {
 				$public_langs = (array) $_POST[ 'public_langs' ];
-				if ( ! in_array( @ $_POST[ 'default_lang' ], $public_langs ) )
+				if ( empty( $_POST[ 'default_lang' ] ) ) {
+					$this->set_admin_error( __( 'You must choose a default language.', 'babble' ) );
+				} else if ( ! in_array( $_POST[ 'default_lang' ], $public_langs ) ) {
 					$this->set_admin_error( __( 'You must set your default language as public.', 'babble' ) );
+				}
 			}
 		}
 		// Finish up, redirecting if we're all OK
@@ -387,7 +420,7 @@ class Babble_Languages extends Babble_Plugin {
 			$this->update_option( 'public_langs', $public_langs );
 			
 			// First the default language
-			$default_lang = @ $_POST[ 'default_lang' ];
+			$default_lang = $_POST[ 'default_lang' ];
 			$this->update_option( 'default_lang', $default_lang );
 			// Now the prefs
 			$this->update_option( 'lang_prefs', $lang_prefs );

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -96,13 +96,6 @@ class Babble_Plugin {
 	protected $type;
 
 	/**
-	 * Note the name of the function to call when the theme is activated.
-	 *
-	 * @var string
-	 **/
-	protected $theme_activation_function;
-
-	/**
 	 * Initiate!
 	 *
 	 * @return void
@@ -115,13 +108,8 @@ class Babble_Plugin {
 		$ds = ( defined( 'DIRECTORY_SEPARATOR' ) ) ? DIRECTORY_SEPARATOR : '\\';
 		$file = str_replace( $ds, '/', __FILE__ );
 		$plugins_dir = str_replace( $ds, '/', dirname( __FILE__ ) );
-		// Setup the dir and url for this plugin/theme
-		if ( 'theme' == $type ) {
-			// This is a theme
-			$this->type = 'theme';
-			$this->dir = get_stylesheet_directory();
-			$this->url = get_stylesheet_directory_uri();
-		} elseif ( stripos( $file, $plugins_dir ) !== false || 'plugin' == $type ) {
+		// Setup the dir and url for this plugin
+		if ( stripos( $file, $plugins_dir ) !== false || 'plugin' == $type ) {
 			// This is a plugin
 			$this->type = 'plugin';
 
@@ -226,27 +214,7 @@ class Babble_Plugin {
 	function register_activation ( $pluginfile = __FILE__, $function = '' ) {
 		if ( $this->type == 'plugin' ) {
 			add_action ('activate_'.basename (dirname ($pluginfile)).'/'.basename ($pluginfile), array ($this, $function == '' ? 'activate' : $function));
-		} elseif ( $this->type == 'theme' ) {
-			$this->theme_activation_function = ( $function ) ? $function : 'activate';
-			add_action ('load-themes.php', array ( $this, 'theme_activation' ) );
 		}
-	}
-
-	/**
-	 * Hack to catch theme activation. We hook the load-themes.php action, look for the
-	 * "activated" GET param and make a big fat assumption if we find it.
-	 *
-	 * @return void
-	 * @author Simon Wheatley
-	 **/
-	public function theme_activation() {
-		$activated = (bool) @ $_GET[ 'activated' ];
-		if ( ! $activated )
-			return;
-		if ( ! $this->theme_activation_function )
-			return;
-		// Looks like the theme might just have been activated, call the registered function
-		$this->{$this->theme_activation_function}();
 	}
 
 	/**

--- a/class-switcher-content.php
+++ b/class-switcher-content.php
@@ -96,7 +96,7 @@ class Babble_Switcher_Menu {
 			$this->jobs         = bbl_get_incomplete_post_jobs( get_option( 'page_for_posts' ) );
 		} else if ( ( !is_admin() and ( is_tax() || is_category() ) ) || $editing_term ) {
 			if ( isset( $_REQUEST[ 'tag_ID' ] ) )
-				$term = get_term( (int) @ $_REQUEST[ 'tag_ID' ], $this->screen->taxonomy );
+				$term = get_term( absint( $_REQUEST[ 'tag_ID' ] ), $this->screen->taxonomy );
 			else
 				$term = get_queried_object();
 			$this->translations = bbl_get_term_translations( $term->term_id, $term->taxonomy );


### PR DESCRIPTION
See #223

Adds actual error checking to replace `@` usage.

The `Babble_Plugin` class also has a bunch of unnecessary code which is only used when the class is being used in a theme, so that's been removed too.

Branches from `fix/exceptions`.
