### PR TITLE
Introduce hashed names for shadow post types and taxonomies

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -299,19 +299,7 @@ class Babble_Post_Public extends Babble_Plugin {
 		foreach ( $langs as $lang ) {
 			$new_args = $args;
 
-
-			// @FIXME: We are in danger of a post_type name being longer than 20 chars
-			// I would prefer to keep the post_type human readable, as human devs and sysadmins always
-			// end up needing to read this kind of thing.
-			// @FIXME: Should I be sanitising these values?
-			$new_post_type = strtolower( "{$post_type}_{$lang->code}" );
-
-			if ( strlen( $new_post_type ) > 20 ) {
-				trigger_error( sprintf( esc_html__( 'Warning: The translated name for the post type %s is longer than %d characters. This *will* cause problems.', 'babble' ),
-					esc_html( $post_type ),
-					20
-				) );
-			}
+			$new_post_type = self::generate_shadow_post_type_name( $post_type, $lang->code );
 
 			if ( false !== $args[ 'rewrite' ] ) {
 				if ( ! is_array( $new_args[ 'rewrite' ] ) )
@@ -360,6 +348,18 @@ class Babble_Post_Public extends Babble_Plugin {
 		do_action( 'bbl_registered_shadow_post_types', $post_type );
 
 		$this->no_recursion = false;
+	}
+
+	public static function generate_shadow_post_type_name( $post_type, $lang_code ) {
+
+		$name = strtolower( "{$post_type}_{$lang_code}" );
+
+		if ( strlen( $name ) > 20 ) {
+			$name = hash( 'crc32b', $name );
+		}
+
+		return $name;
+
 	}
 
 	/**

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -163,9 +163,7 @@ class Babble_Taxonomies extends Babble_Plugin {
 				$new_args[ 'query_var' ] = $new_args[ 'rewrite' ][ 'slug' ] = $this->get_slug_in_lang( $slug, $lang->code );
 			}
 
-			// @FIXME: Note currently we are in danger of a taxonomy name being longer than 32 chars
-			// Perhaps we need to create some kind of map like (taxonomy) + (lang) => (shadow translated taxonomy)
-			$new_taxonomy = strtolower( "{$taxonomy}_{$lang->code}" );
+			$new_taxonomy = self::generate_shadow_taxonomy_name( $taxonomy, $lang->code );
 
 			$this->taxonomies[ $new_taxonomy ] = $taxonomy;
 			if ( ! isset( $this->lang_map[ $lang->code ] ) || ! is_array( $this->lang_map[ $lang->code ] ) )
@@ -179,6 +177,19 @@ class Babble_Taxonomies extends Babble_Plugin {
 
 		$this->no_recursion = false;
 	}
+
+	public static function generate_shadow_taxonomy_name( $taxonomy, $lang_code ) {
+
+		$name = strtolower( "{$taxonomy}_{$lang_code}" );
+
+		if ( strlen( $name ) > 32 ) {
+			$name = hash( 'crc32b', $name );
+		}
+
+		return $name;
+
+	}
+
 
 	public function ignored_taxonomies() {
 		return array( 'post_translation', 'term_translation' );
@@ -834,7 +845,7 @@ class Babble_Taxonomies extends Babble_Plugin {
 
 	public function initialise_translation( $origin_term, $taxonomy, $lang_code ) {
 
-		$new_taxonomy = $this->get_slug_in_lang( $taxonomy, $lang_code );
+		$new_taxonomy = self::generate_shadow_taxonomy_name( $taxonomy, $lang_code );
 
 		$transid = $this->get_transid( $origin_term->term_id );
 

--- a/tests/test-shadows.php
+++ b/tests/test-shadows.php
@@ -1,0 +1,108 @@
+<?php
+
+class Test_Shadows extends Babble_UnitTestCase {
+
+	public function setUp() {
+		$this->install_languages();
+
+		parent::setUp();
+	}
+
+	public function test_shadow_assumptions() {
+		global $wpdb;
+
+		if ( ! method_exists( $wpdb, 'get_col_length' ) ) {
+			$this->markTestSkipped( 'The wpdb::get_col_length method does not exist' );
+		}
+
+		$post_type = $wpdb->get_col_length( $wpdb->posts, 'post_type' );
+		$this->assertSame( 20, intval( $post_type['length'] ) );
+
+		$term = $wpdb->get_col_length( $wpdb->terms, 'name' );
+		$this->assertSame( 200, intval( $term['length'] ) );
+
+		$taxonomy = $wpdb->get_col_length( $wpdb->term_taxonomy, 'taxonomy' );
+		$this->assertSame( 32, intval( $taxonomy['length'] ) );
+	}
+
+	public function test_post_shadow_name() {
+
+		$this->assertSame( 'en_US', get_locale() );
+
+		$en = $this->factory->post->create_and_get( array(
+			'post_type' => 'post',
+		) );
+		$uk = $this->create_post_translation( $en, 'en_GB' );
+
+		$post_type    = 'post_en_gb';
+		$uk_post_type = Babble_Post_Public::generate_shadow_post_type_name( $en->post_type, 'en_GB' );
+		$uk_post      = get_post( $uk->ID );
+
+		$this->assertSame( $post_type, $uk_post_type );
+		$this->assertSame( $uk_post_type, $uk_post->post_type );
+
+	}
+
+	public function test_long_post_shadow_name() {
+
+		# Register a post type with a twenty-character name
+		$post_type = str_repeat( 'a', 20 );
+		register_post_type( $post_type, array(
+			'public' => true,
+		) );
+
+		$this->assertSame( 'en_US', get_locale() );
+
+		$en = $this->factory->post->create_and_get( array(
+			'post_type' => $post_type,
+		) );
+		$uk = $this->create_post_translation( $en, 'en_GB' );
+
+		$uk_post_type = Babble_Post_Public::generate_shadow_post_type_name( $en->post_type, 'en_GB' );
+		$uk_post      = get_post( $uk->ID );
+
+		$this->assertTrue( strlen( $uk_post->post_type ) <= 20 );
+		$this->assertSame( $uk_post_type, $uk_post->post_type );
+
+	}
+
+	public function test_taxonomy_shadow_name() {
+
+		$this->assertSame( 'en_US', get_locale() );
+
+		$en = $this->factory->category->create_and_get();
+		$uk = $this->create_term_translation( $en, 'en_GB' );
+
+		$tax_name    = 'category_en_gb';
+		$uk_tax_name = Babble_Taxonomies::generate_shadow_taxonomy_name( $en->taxonomy, 'en_GB' );
+		$uk_term     = get_term( $uk->term_id, $uk->taxonomy );
+
+		$this->assertSame( $tax_name, $uk_tax_name );
+		$this->assertSame( $uk_tax_name, $uk_term->taxonomy );
+
+	}
+
+	public function test_long_taxonomy_shadow_name() {
+
+		# Register a taxonomy with a 32-character name
+		$taxonomy = str_repeat( 'a', 32 );
+		register_taxonomy( $taxonomy, 'post', array(
+			'public' => true,
+		) );
+
+		$this->assertSame( 'en_US', get_locale() );
+
+		$en = $this->factory->term->create_and_get( array(
+			'taxonomy' => $taxonomy,
+		) );
+		$uk = $this->create_term_translation( $en, 'en_GB' );
+
+		$uk_tax_name = Babble_Taxonomies::generate_shadow_taxonomy_name( $en->taxonomy, 'en_GB' );
+		$uk_term     = get_term( $uk->term_id, $uk->taxonomy );
+
+		$this->assertTrue( strlen( $uk_term->taxonomy ) <= 32 );
+		$this->assertSame( $uk_tax_name, $uk_term->taxonomy );
+
+	}
+
+}


### PR DESCRIPTION
See discussion on #247.

This replaces overly long post type and taxonomy names with a crc32 hash of the name and language code. A crc32 hash is an 8 byte hexadecimal string.

Also introduces tests for hashed and non-hashed post type and taxonomy names, and tests for our assumptions about field lengths.
