### PR TITLE
Fix input sanitisation

### DIFF
--- a/class-jobs.php
+++ b/class-jobs.php
@@ -675,13 +675,15 @@ class Babble_Jobs extends Babble_Plugin {
 
 				$meta_data = stripslashes_deep( $_POST['bbl_translation']['meta'] );
 
-				foreach ( $meta_data as $meta_key => $meta_value ) {
+				foreach ( $objects['meta'] as $meta_key => $meta_field ) {
 
-					update_post_meta( $job->ID, "bbl_meta_{$meta_key}", $meta_value );
+					$value = wp_kses_post( $meta_data[ $meta_key ] );
+
+					update_post_meta( $job->ID, "bbl_meta_{$meta_key}", $value );
 
 					if ( 'complete' == $job->post_status ) {
 						if ( current_user_can( 'publish_post', $job->ID ) ) {
-							update_post_meta( $trans->ID, $meta_key, $meta_value );
+							update_post_meta( $trans->ID, $meta_key, $value );
 						}
 					}
 

--- a/class-jobs.php
+++ b/class-jobs.php
@@ -696,11 +696,14 @@ class Babble_Jobs extends Babble_Plugin {
 		if ( $edit_terms_nonce and wp_verify_nonce( $edit_terms_nonce, "bbl_translation_edit_terms_{$job->ID}") ) {
 
 			$terms_data = stripslashes_deep( $_POST['bbl_translation']['terms'] );
-			$terms      = get_post_meta( $job->ID, 'bbl_job_term', false );
+			$job_terms  = $objects['terms'];
+
+			foreach ( $job_terms as $taxo => $terms ) {
 
 			foreach ( $terms as $term_info ) {
 
-				list( $taxo, $term_id ) = explode( '|', $term_info );
+				$term_id = $term_info->term_id;
+
 				$term = get_term( $term_id, $taxo );
 				$terms_data[$term_id]['slug'] = sanitize_title( $terms_data[$term_id]['slug'] );
 
@@ -717,12 +720,14 @@ class Babble_Jobs extends Babble_Plugin {
 					$terms_data[$term->term_id]['term_id'] = $trans->term_id;
 
 					$args = array(
-						'name' => $terms_data[$term->term_id]['name'],
+						'name' => wp_kses_post( $terms_data[$term->term_id]['name'] ),
 						'slug' => '',
 					);
 					wp_update_term( absint( $trans->term_id ), $trans->taxonomy, $args );
 
 				}
+
+			}
 
 			}
 

--- a/class-jobs.php
+++ b/class-jobs.php
@@ -594,6 +594,8 @@ class Babble_Jobs extends Babble_Plugin {
 		else
 			$lang_code = reset( $language )->name;
 
+		$objects = $this->get_job_objects( $job );
+
 		if ( $origin_post_nonce and wp_verify_nonce( $origin_post_nonce, "bbl_translation_origin_post_{$job->ID}") ) {
 			if ( $origin_post = get_post( absint( $_POST['bbl_origin_post'] ) ) ) {
 				add_post_meta( $job->ID, 'bbl_job_post', "{$origin_post->post_type}|{$origin_post->ID}", true );
@@ -627,7 +629,7 @@ class Babble_Jobs extends Babble_Plugin {
 			list( $post_type, $post_id ) = explode( '|', $post_info );
 			$post = get_post( $post_id );
 
-			update_post_meta( $job->ID, "bbl_post_{$post_id}", $post_data );
+			update_post_meta( $job->ID, "bbl_post_{$post_id}", sanitize_post( $post_data, 'db' ) );
 
 			if ( 'pending' == $job->post_status ) {
 

--- a/class-languages.php
+++ b/class-languages.php
@@ -386,13 +386,13 @@ class Babble_Languages extends Babble_Plugin {
 			$lang_pref = new stdClass;
 
 			if ( ! empty( $_POST[ 'display_name_' . $code ] ) ) {
-				$lang_pref->display_name = $_POST[ 'display_name_' . $code ];
+				$lang_pref->display_name = wp_strip_all_tags( wp_unslash( $_POST[ 'display_name_' . $code ] ) );
 			} else {
 				$lang_pref->display_name = $lang->name;
 			}
 
 			if ( ! empty( $_POST[ 'url_prefix_' . $code ] ) ) {
-				$lang_pref->url_prefix = $_POST[ 'url_prefix_' . $code ];
+				$lang_pref->url_prefix = wp_strip_all_tags( wp_unslash( $_POST[ 'url_prefix_' . $code ] ) );
 			} else {
 				$lang_pref->url_prefix = $lang->url_prefix;
 			}
@@ -418,7 +418,9 @@ class Babble_Languages extends Babble_Plugin {
 			$active_langs = array();
 			if ( ! empty( $_POST[ 'active_langs' ] ) && is_array( $_POST[ 'active_langs' ] ) ) {
 				foreach ( $_POST[ 'active_langs' ] as $code ) {
-					$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+					if ( isset( $this->available_langs[ $code ] ) ) {
+						$active_langs[ $langs[ $code ]->url_prefix ] = $code;
+					}
 				}
 			}
 			if ( count( $active_langs ) < 2 ) {
@@ -429,10 +431,16 @@ class Babble_Languages extends Babble_Plugin {
 				$this->langs = $langs;
 				$this->update_option( 'langs', $this->langs );
 			}
-			if ( ! isset( $_POST[ 'public_langs' ] ) ) {
+			if ( empty( $_POST[ 'public_langs' ] ) || ! is_array( $_POST[ 'public_langs' ] ) ) {
 				$this->set_admin_error( __( 'You must set at least your default language as public.', 'babble' ) );
 			} else {
-				$public_langs = (array) $_POST[ 'public_langs' ];
+				$public_langs = array();
+				foreach ( $_POST[ 'public_langs' ] as $code ) {
+					if ( isset( $this->available_langs[ $code ] ) ) {
+						$public_langs[] = $code;
+					}
+				}
+
 				if ( empty( $_POST[ 'default_lang' ] ) ) {
 					$this->set_admin_error( __( 'You must choose a default language.', 'babble' ) );
 				} else if ( ! in_array( $_POST[ 'default_lang' ], $public_langs ) ) {


### PR DESCRIPTION
See #227.

This implements the following:
- When saving a translation job, loops over only the job's meta fields and terms, and adds KSES to meta field values and term names.
- When saving a translation job, sanitise the post data that's stored in the job meta. This is just so it's representative of the post data once it's saved with `wp_update_post()`. There is no need for manual sanitisation because this is handled inside `wp_insert_post()` and `sanitize_post()`.
- When saving the language settings, sanitise the display name, URL prefix, active langs, and public langs.
