### PR TITLE
Remove global usage and switch to a registry

### DIFF
--- a/api.php
+++ b/api.php
@@ -35,8 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  * @access public
  **/
 function bbl_get_current_content_lang_code() {
-	global $bbl_locale;
-	return $bbl_locale->get_content_lang();
+	return Babble::get( 'locale' )->get_content_lang();
 }
 
 /**
@@ -48,8 +47,7 @@ function bbl_get_current_content_lang_code() {
  * @access public
  **/
 function bbl_get_current_interface_lang_code() {
-	global $bbl_locale;
-	return $bbl_locale->get_interface_lang();
+	return Babble::get( 'locale' )->get_interface_lang();
 }
 
 /**
@@ -71,8 +69,7 @@ function bbl_get_current_lang_code() {
  * @access public
  **/
 function bbl_is_public_lang( $lang_code ) {
-	global $bbl_languages;
-	return $bbl_languages->is_public_lang( $lang_code );
+	return Babble::get( 'languages' )->is_public_lang( $lang_code );
 }
 
 /**
@@ -85,8 +82,7 @@ function bbl_is_public_lang( $lang_code ) {
  * @return bool Whether the switch was successful
  **/
 function bbl_switch_to_lang( $lang ) {
-	global $bbl_locale;
-	return $bbl_locale->switch_to_lang( $lang );
+	return Babble::get( 'locale' )->switch_to_lang( $lang );
 }
 
 /**
@@ -98,8 +94,7 @@ function bbl_switch_to_lang( $lang ) {
  * @return void
  **/
 function bbl_restore_lang() {
-	global $bbl_locale;
-	$bbl_locale->restore_lang();
+	Babble::get( 'locale' )->restore_lang();
 }
 
 /**
@@ -112,8 +107,7 @@ function bbl_restore_lang() {
  * @access public
  **/
 function bbl_get_term_translations( $term, $taxonomy ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_term_translations( $term, $taxonomy );
+	return Babble::get( 'taxonomies' )->get_term_translations( $term, $taxonomy );
 }
 
 /**
@@ -125,8 +119,7 @@ function bbl_get_term_translations( $term, $taxonomy ) {
  * @access public
  **/
 function bbl_get_term_jobs( $term, $taxonomy ) {
-	global $bbl_jobs;
-	return $bbl_jobs->get_term_jobs( $term, $taxonomy );
+	return Babble::get( 'jobs' )->get_term_jobs( $term, $taxonomy );
 }
 
 /**
@@ -140,8 +133,7 @@ function bbl_get_term_jobs( $term, $taxonomy ) {
  * @access public
  **/
 function bbl_get_new_term_translation_url( $default_term, $lang, $taxonomy = null ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_new_term_translation_url( $default_term, $lang, $taxonomy );
+	return Babble::get( 'taxonomies' )->get_new_term_translation_url( $default_term, $lang, $taxonomy );
 }
 
 /**
@@ -151,8 +143,7 @@ function bbl_get_new_term_translation_url( $default_term, $lang, $taxonomy = nul
  * @return string The lang code
  **/
 function bbl_get_taxonomy_lang_code( $taxonomy ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_taxonomy_lang_code( $taxonomy );
+	return Babble::get( 'taxonomies' )->get_taxonomy_lang_code( $taxonomy );
 }
 
 /**
@@ -163,8 +154,7 @@ function bbl_get_taxonomy_lang_code( $taxonomy ) {
  * @return string The name of the base taxonomy
  **/
 function bbl_get_base_taxonomy( $taxonomy ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_base_taxonomy( $taxonomy );
+	return Babble::get( 'taxonomies' )->get_base_taxonomy( $taxonomy );
 }
 
 /**
@@ -175,8 +165,7 @@ function bbl_get_base_taxonomy( $taxonomy ) {
  * @return string The taxonomy name
  **/
 function bbl_get_taxonomy_in_lang( $taxonomy, $lang_code = null ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_taxonomy_in_lang( $taxonomy, $lang_code );
+	return Babble::get( 'taxonomies' )->get_taxonomy_in_lang( $taxonomy, $lang_code );
 }
 
 /**
@@ -207,8 +196,7 @@ function bbl_is_translated_post_type( $post_type ) {
  * @return string A translated slug
  **/
 function bbl_get_taxonomy_slug_in_lang( $slug, $lang_code = null ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_slug_in_lang( $slug, $lang_code );
+	return Babble::get( 'taxonomies' )->get_slug_in_lang( $slug, $lang_code );
 }
 
 /**
@@ -221,8 +209,7 @@ function bbl_get_taxonomy_slug_in_lang( $slug, $lang_code = null ) {
  * @access public
  **/
 function bbl_get_post_translations( $post ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_post_translations( $post );
+	return Babble::get( 'post_public' )->get_post_translations( $post );
 }
 
 /**
@@ -234,8 +221,7 @@ function bbl_get_post_translations( $post ) {
  * @access public
  **/
 function bbl_get_incomplete_post_jobs( $post ) {
-	global $bbl_jobs;
-	return $bbl_jobs->get_incomplete_post_jobs( $post );
+	return Babble::get( 'jobs' )->get_incomplete_post_jobs( $post );
 }
 
 /**
@@ -247,8 +233,7 @@ function bbl_get_incomplete_post_jobs( $post ) {
  * @access public
  **/
 function bbl_get_default_lang_post( $post ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_default_lang_post( $post );
+	return Babble::get( 'post_public' )->get_default_lang_post( $post );
 }
 
 /**
@@ -259,8 +244,7 @@ function bbl_get_default_lang_post( $post ) {
  * @access public
  **/
 function bbl_get_post_lang_code( $post ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_post_lang_code( $post );
+	return Babble::get( 'post_public' )->get_post_lang_code( $post );
 }
 
 /**
@@ -273,8 +257,7 @@ function bbl_get_post_lang_code( $post ) {
  * @access public
  **/
 function bbl_get_new_post_translation_url( $default_post, $lang ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_new_post_translation_url( $default_post, $lang );
+	return Babble::get( 'post_public' )->get_new_post_translation_url( $default_post, $lang );
 }
 
 /**
@@ -286,10 +269,9 @@ function bbl_get_new_post_translation_url( $default_post, $lang ) {
  * @return string A post type name, e.g. "page" or "post"
  **/
 function bbl_get_post_type_in_lang( $original_post_type, $lang_code = null ) {
-	global $bbl_post_public;
 	if ( is_null( $lang_code ) )
 		$lang_code = bbl_get_current_lang_code();
-	return $bbl_post_public->get_post_type_in_lang( $original_post_type, $lang_code );
+	return Babble::get( 'post_public' )->get_post_type_in_lang( $original_post_type, $lang_code );
 }
 
 add_filter( 'bbl_get_content_post_type', 'bbl_get_post_type_in_lang' );
@@ -329,8 +311,7 @@ function bbl_is_page( $page = '' ) {
  * @return object|boolean The WP Post object, or if $fallback was false and no post then returns false
  **/
 function bbl_get_post_in_lang( $post, $lang_code, $fallback = true ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_post_in_lang( $post, $lang_code, $fallback );
+	return Babble::get( 'post_public' )->get_post_in_lang( $post, $lang_code, $fallback );
 }
 
 /**
@@ -343,8 +324,7 @@ function bbl_get_post_in_lang( $post, $lang_code, $fallback = true ) {
  * @return object|boolean The term object, or if $fallback was false and no term then returns false
  **/
 function bbl_get_term_in_lang( $term, $taxonomy, $lang_code, $fallback = true ) {
-	global $bbl_taxonomies;
-	return $bbl_taxonomies->get_term_in_lang( $term, $taxonomy, $lang_code, $fallback );
+	return Babble::get( 'taxonomies' )->get_term_in_lang( $term, $taxonomy, $lang_code, $fallback );
 }
 
 /**
@@ -355,9 +335,8 @@ function bbl_get_term_in_lang( $term, $taxonomy, $lang_code, $fallback = true ) 
  * @return string A translated slug
  **/
 function bbl_get_post_type_slug_in_lang( $slug, $lang_code = null ) {
-	global $bbl_post_public;
 	$lang = bbl_get_lang( $lang_code );
-	return $bbl_post_public->get_slug_in_lang( $slug, $lang );
+	return Babble::get( 'post_public' )->get_slug_in_lang( $slug, $lang );
 }
 
 /**
@@ -451,8 +430,7 @@ function bbl_get_post_type_archive_link_in_lang( $post_type, $lang_code = null )
  * @return string The name of the base post type
  **/
 function bbl_get_base_post_type( $post_type ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_base_post_type( $post_type );
+	return Babble::get( 'post_public' )->get_base_post_type( $post_type );
 }
 
 /**
@@ -461,8 +439,7 @@ function bbl_get_base_post_type( $post_type ) {
  * @return array An array of post_type objects
  **/
 function bbl_get_base_post_types() {
-	global $bbl_post_public;
-	return $bbl_post_public->get_base_post_types();
+	return Babble::get( 'post_public' )->get_base_post_types();
 }
 
 /**
@@ -473,8 +450,7 @@ function bbl_get_base_post_types() {
  * @return array The names of all the related shadow post types
  **/
 function bbl_get_shadow_post_types( $base_post_type ) {
-	global $bbl_post_public;
-	return $bbl_post_public->get_shadow_post_types( $base_post_type );
+	return Babble::get( 'post_public' )->get_shadow_post_types( $base_post_type );
 }
 
 /**
@@ -493,8 +469,7 @@ function bbl_get_shadow_post_types( $base_post_type ) {
  * @return array An array of Babble language objects
  **/
 function bbl_get_active_langs() {
-	global $bbl_languages;
-	return $bbl_languages->get_active_langs();
+	return Babble::get( 'languages' )->get_active_langs();
 }
 
 /**
@@ -504,8 +479,7 @@ function bbl_get_active_langs() {
  * @return object|boolean A Babble language object
  **/
 function bbl_get_lang( $lang_code ) {
-	global $bbl_languages;
-	return $bbl_languages->get_lang( $lang_code );
+	return Babble::get( 'languages' )->get_lang( $lang_code );
 }
 
 /**
@@ -517,8 +491,7 @@ function bbl_get_lang( $lang_code ) {
  * @return object A Babble language object
  **/
 function bbl_get_current_lang() {
-	global $bbl_languages;
-	return $bbl_languages->get_current_lang();
+	return Babble::get( 'languages' )->get_current_lang();
 }
 
 /**
@@ -527,8 +500,7 @@ function bbl_get_current_lang() {
  * @return string A language code, e.g. "he_IL"
  **/
 function bbl_get_default_lang_code() {
-	global $bbl_languages;
-	return $bbl_languages->get_default_lang_code();
+	return Babble::get( 'languages' )->get_default_lang_code();
 }
 
 /**
@@ -537,8 +509,7 @@ function bbl_get_default_lang_code() {
  * @return object A language object
  **/
 function bbl_get_default_lang() {
-	global $bbl_languages;
-	return $bbl_languages->get_default_lang();
+	return Babble::get( 'languages' )->get_default_lang();
 }
 
 /**
@@ -568,7 +539,7 @@ function bbl_is_default_lang( $lang_code = null ) {
  * @return string The language URL prefix set by the admin, e.g. "de"
  **/
 function bbl_get_default_lang_url_prefix() {
-	global $bbl_languages;
+	$bbl_languages = Babble::get( 'languages' );
 	$code = $bbl_languages->get_default_lang_code();
 	return $bbl_languages->get_url_prefix_from_code( $code );
 }
@@ -580,8 +551,7 @@ function bbl_get_default_lang_url_prefix() {
  * @return string The language code, or false
  **/
 function bbl_get_lang_from_prefix( $url_prefix ) {
-	global $bbl_languages;
-	return $bbl_languages->get_code_from_url_prefix( $url_prefix );
+	return Babble::get( 'languages' )->get_code_from_url_prefix( $url_prefix );
 }
 
 /**
@@ -591,8 +561,7 @@ function bbl_get_lang_from_prefix( $url_prefix ) {
  * @return string The language URL prefix set by the admin, e.g. "de"
  **/
 function bbl_get_prefix_from_lang_code( $lang_code ) {
-	global $bbl_languages;
-	return $bbl_languages->get_url_prefix_from_code( $lang_code );
+	return Babble::get( 'languages' )->get_url_prefix_from_code( $lang_code );
 }
 
 /**
@@ -602,8 +571,7 @@ function bbl_get_prefix_from_lang_code( $lang_code ) {
  * @return array An array of admin menu nodes
  **/
 function bbl_get_switcher_links( $id_prefix = '' ) {
-	global $bbl_switcher_menu;
-	return $bbl_switcher_menu->get_switcher_links( $id_prefix );
+	return Babble::get( 'switcher_menu' )->get_switcher_links( $id_prefix );
 }
 
 /**
@@ -612,8 +580,7 @@ function bbl_get_switcher_links( $id_prefix = '' ) {
  * @return void
  **/
 function bbl_start_logging() {
-	global $bbl_log;
-	$bbl_log->logging = true;
+	Babble::get( 'log' )->logging = true;
 }
 
 /**
@@ -622,8 +589,7 @@ function bbl_start_logging() {
  * @return void
  **/
 function bbl_stop_logging() {
-	global $bbl_log;
-	$bbl_log->logging = false;
+	Babble::get( 'log' )->logging = false;
 }
 
 /**
@@ -634,7 +600,7 @@ function bbl_stop_logging() {
  * @return void
  **/
 function bbl_log( $msg, $force = false ) {
-	global $bbl_log;
+	$bbl_log = Babble::get( 'log' );
 	if ( $bbl_log || $force ) {
 		$bbl_log->log( $msg );
 	}
@@ -646,6 +612,5 @@ function bbl_log( $msg, $force = false ) {
  * @return boolean True for yes, natch
  **/
 function bbl_is_logging() {
-	global $bbl_log;
-	return $bbl_log->logging;
+	return Babble::get( 'log' )->logging;
 }

--- a/babble.php
+++ b/babble.php
@@ -109,39 +109,3 @@ Babble::set( 'switcher_menu',      new Babble_Switcher_Menu );
 Babble::set( 'switcher_interface', new Babble_Switcher_Interface );
 Babble::set( 'admin_bar',          new Babble_Admin_bar );
 Babble::set( 'translator',         new Babble_Translator );
-
-
-// Globals
-
-global $bbl_log;
-$bbl_log = Babble::get( 'log' );
-
-global $bbl_jobs;
-$bbl_jobs = Babble::get( 'jobs' );
-
-global $bbl_languages;
-$bbl_languages = Babble::get( 'languages' );
-
-global $bbl_locale;
-$bbl_locale = Babble::get( 'locale' );
-
-global $bbl_post_public;
-$bbl_post_public = Babble::get( 'post_public' );
-
-global $bbl_comment;
-$bbl_comment = Babble::get( 'comment' );
-
-global $bbl_taxonomies;
-$bbl_taxonomies = Babble::get( 'taxonomies' );
-
-global $bbl_switcher_menu;
-$bbl_switcher_menu = Babble::get( 'switcher_menu' );
-
-global $bbl_switcher_interface;
-$bbl_switcher_interface = Babble::get( 'switcher_interface' );
-
-global $bbl_admin_bar;
-$bbl_admin_bar = Babble::get( 'admin_bar' );
-
-global $bbl_translator;
-$bbl_translator = Babble::get( 'translator' );

--- a/babble.php
+++ b/babble.php
@@ -74,3 +74,74 @@ require_once 'class-admin-bar.php';
 require_once 'class-translator.php';
 
 require_once 'miscellaneous.php';
+
+final class Babble {
+
+	private static $registry = array();
+
+	private function __construct() {
+	}
+
+	public static function set( $name, $instance ) {
+		self::$registry[ $name ] = $instance;
+	}
+
+	public static function get( $name ) {
+		if ( array_key_exists( $name, self::$registry ) ) {
+			return self::$registry[ $name ];
+		} else {
+			return null;
+		}
+	}
+
+}
+
+// Registry
+
+Babble::set( 'log',                new Babble_Log );
+Babble::set( 'jobs',               new Babble_Jobs );
+Babble::set( 'languages',          new Babble_Languages );
+Babble::set( 'locale',             new Babble_Locale );
+Babble::set( 'post_public',        new Babble_Post_Public );
+Babble::set( 'comment',            new Babble_Comment );
+Babble::set( 'taxonomies',         new Babble_Taxonomies );
+Babble::set( 'switcher_menu',      new Babble_Switcher_Menu );
+Babble::set( 'switcher_interface', new Babble_Switcher_Interface );
+Babble::set( 'admin_bar',          new Babble_Admin_bar );
+Babble::set( 'translator',         new Babble_Translator );
+
+
+// Globals
+
+global $bbl_log;
+$bbl_log = Babble::get( 'log' );
+
+global $bbl_jobs;
+$bbl_jobs = Babble::get( 'jobs' );
+
+global $bbl_languages;
+$bbl_languages = Babble::get( 'languages' );
+
+global $bbl_locale;
+$bbl_locale = Babble::get( 'locale' );
+
+global $bbl_post_public;
+$bbl_post_public = Babble::get( 'post_public' );
+
+global $bbl_comment;
+$bbl_comment = Babble::get( 'comment' );
+
+global $bbl_taxonomies;
+$bbl_taxonomies = Babble::get( 'taxonomies' );
+
+global $bbl_switcher_menu;
+$bbl_switcher_menu = Babble::get( 'switcher_menu' );
+
+global $bbl_switcher_interface;
+$bbl_switcher_interface = Babble::get( 'switcher_interface' );
+
+global $bbl_admin_bar;
+$bbl_admin_bar = Babble::get( 'admin_bar' );
+
+global $bbl_translator;
+$bbl_translator = Babble::get( 'translator' );

--- a/class-admin-bar.php
+++ b/class-admin-bar.php
@@ -43,6 +43,3 @@ class Babble_Admin_bar extends Babble_Plugin {
 	}
 
 }
-
-global $bbl_admin_bar;
-$bbl_admin_bar = new Babble_Admin_bar();

--- a/class-babble-log.php
+++ b/class-babble-log.php
@@ -44,6 +44,3 @@ class Babble_Log {
 	}
 
 }
-
-global $bbl_log;
-$bbl_log = new Babble_Log();

--- a/class-comment.php
+++ b/class-comment.php
@@ -83,6 +83,3 @@ class Babble_Comment extends Babble_Plugin {
 	// =========================
 
 }
-
-global $bbl_comment;
-$bbl_comment = new Babble_Comment();

--- a/class-jobs.php
+++ b/class-jobs.php
@@ -569,7 +569,8 @@ class Babble_Jobs extends Babble_Plugin {
 
 	public function save_job( $job_id, WP_Post $job ) {
 
-		global $bbl_post_public, $bbl_taxonomies;
+		$bbl_post_public = Babble::get( 'post_public' );
+		$bbl_taxonomies = Babble::get( 'taxonomies' );
 
 		if ( $this->no_recursion )
 			return;
@@ -1086,11 +1087,11 @@ class Babble_Jobs extends Babble_Plugin {
 	 * @param  array  $args Args array containing a `post_id` element.
 	 */
 	public function create_empty_translation( array $args ) {
-		global $bbl_post_public;
-
 		if ( !$post = get_post( $args['post_id'] ) ) {
 			return;
 		}
+
+		$bbl_post_public = Babble::get( 'post_public' );
 
 		foreach ( bbl_get_active_langs() as $lang ) {
 
@@ -1239,6 +1240,3 @@ class Babble_Jobs extends Babble_Plugin {
 	}
 
 }
-
-global $bbl_jobs;
-$bbl_jobs = new Babble_Jobs();

--- a/class-languages.php
+++ b/class-languages.php
@@ -288,8 +288,7 @@ class Babble_Languages extends Babble_Plugin {
 	 * @return object|boolean A Babble language object
 	 **/
 	public function get_current_lang() {
-		global $bbl_locale;
-		return $this->get_lang( $bbl_locale->get_lang() );
+		return $this->get_lang( Babble::get( 'locale' )->get_lang() );
 	}
 
 	/**
@@ -582,6 +581,3 @@ class Babble_Languages extends Babble_Plugin {
 		$this->public_langs = array( $locale );
 	}
 }
-
-global $bbl_languages;
-$bbl_languages = new Babble_Languages();

--- a/class-locale.php
+++ b/class-locale.php
@@ -488,9 +488,8 @@ class Babble_Locale {
 	 * @return void
 	 **/
 	protected function set_content_lang( $code ) {
-		global $bbl_languages;
 		// Set the content language in the application
-		$url_prefix = $bbl_languages->get_url_prefix_from_code( $code );
+		$url_prefix = Babble::get( 'languages' )->get_url_prefix_from_code( $code );
 		if ( ! $url_prefix ) {
 			return false;
 		}
@@ -519,7 +518,6 @@ class Babble_Locale {
 	 * @return void
 	 **/
 	protected function set_content_lang_from_prefix( $url_prefix ) {
-		global $bbl_languages;
 		$this->set_content_lang( bbl_get_lang_from_prefix( $url_prefix ) );
 	}
 
@@ -640,6 +638,3 @@ class Babble_Locale {
 	}
 
 }
-
-global $bbl_locale;
-$bbl_locale = new Babble_Locale();

--- a/class-post-public.php
+++ b/class-post-public.php
@@ -1660,6 +1660,3 @@ class Babble_Post_Public extends Babble_Plugin {
 
 
 }
-
-global $bbl_post_public;
-$bbl_post_public = new Babble_Post_Public();

--- a/class-switcher-content.php
+++ b/class-switcher-content.php
@@ -421,7 +421,7 @@ class Babble_Switcher_Menu {
 	 * @return void
 	 **/
 	protected function add_front_page_link( $lang ) {
-		global $bbl_locale;
+		$bbl_locale = Babble::get( 'locale' );
 		$classes = array();
 		remove_filter( 'home_url', array( $bbl_locale, 'home_url'), null, 2 );
 		$href = home_url( "$lang->url_prefix/" );
@@ -552,6 +552,3 @@ class Babble_Switcher_Menu {
 	}
 
 }
-
-global $bbl_switcher_menu;
-$bbl_switcher_menu = new Babble_Switcher_Menu();

--- a/class-switcher-interface.php
+++ b/class-switcher-interface.php
@@ -30,6 +30,3 @@ class Babble_Switcher_Interface extends Babble_Plugin {
 	}
 
 }
-
-global $bbl_switcher_interface;
-$bbl_switcher_interface = new Babble_Switcher_Interface;

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -1010,6 +1010,3 @@ class Babble_Taxonomies extends Babble_Plugin {
 	}
 
 }
-
-global $bbl_taxonomies;
-$bbl_taxonomies = new Babble_Taxonomies();

--- a/class-translator.php
+++ b/class-translator.php
@@ -61,6 +61,3 @@ class Babble_Translator extends Babble_Plugin {
 	}
 
 }
-
-global $bbl_translator;
-$bbl_translator = new Babble_translator();

--- a/globals.php
+++ b/globals.php
@@ -1,0 +1,69 @@
+<?php
+/*
+Plugin Name: Babble: Global Variables
+Plugin URI:  http://babbleplugin.com/
+Description: Back-compat plugin for sites which need to retain Babble's global variables, which were used prior to version 1.6.
+Version:     1.0
+Author:      Automattic
+Author URI:  https://automattic.com/
+Text Domain: babble
+Domain Path: /languages/
+License:     GPL v2 or later
+
+Copyright 2011-2015 Automattic Ltd
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*/
+
+/**
+ * Adds Babble's components as global variables.
+ */
+function babble_globals() {
+	global $bbl_log;
+	$bbl_log = Babble::get( 'log' );
+
+	global $bbl_jobs;
+	$bbl_jobs = Babble::get( 'jobs' );
+
+	global $bbl_languages;
+	$bbl_languages = Babble::get( 'languages' );
+
+	global $bbl_locale;
+	$bbl_locale = Babble::get( 'locale' );
+
+	global $bbl_post_public;
+	$bbl_post_public = Babble::get( 'post_public' );
+
+	global $bbl_comment;
+	$bbl_comment = Babble::get( 'comment' );
+
+	global $bbl_taxonomies;
+	$bbl_taxonomies = Babble::get( 'taxonomies' );
+
+	global $bbl_switcher_menu;
+	$bbl_switcher_menu = Babble::get( 'switcher_menu' );
+
+	global $bbl_switcher_interface;
+	$bbl_switcher_interface = Babble::get( 'switcher_interface' );
+
+	global $bbl_admin_bar;
+	$bbl_admin_bar = Babble::get( 'admin_bar' );
+
+	global $bbl_translator;
+	$bbl_translator = Babble::get( 'translator' );
+}
+
+add_action( 'plugins_loaded', 'babble_globals', 1 );

--- a/tests/babble-testcase.php
+++ b/tests/babble-testcase.php
@@ -31,7 +31,9 @@ class Babble_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	public function go_to( $url ) {
-		global $locale, $bbl_locale;
+		global $locale;
+
+		$bbl_locale = Babble::get( 'locale' );
 		$locale = null;
 		$bbl_locale->content_lang = null;
 		$bbl_locale->interface_lang = null;
@@ -43,9 +45,8 @@ class Babble_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	protected function create_post_translation( WP_Post $origin, $lang_code ) {
-		global $bbl_post_public;
 
-		$post = $bbl_post_public->initialise_translation( $origin, $lang_code );
+		$post = Babble::get( 'post_public' )->initialise_translation( $origin, $lang_code );
 		$post->post_status = 'publish';
 		$post->post_title  = rand_str();
 		$post->post_name   = rand_str();
@@ -56,16 +57,14 @@ class Babble_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	protected function create_term_translation( $origin, $lang_code ) {
-		global $bbl_taxonomies;
 
-		$term = $bbl_taxonomies->initialise_translation( $origin, $origin->taxonomy, $lang_code );
+		$term = Babble::get( 'taxonomies' )->initialise_translation( $origin, $origin->taxonomy, $lang_code );
 
 		return $term;
 
 	}
 
 	protected function install_languages() {
-		global $bbl_languages;
 
 		if ( file_exists( $file = ABSPATH . 'wp-admin/includes/translation-install.php' ) ) {
 			require_once $file;
@@ -133,7 +132,7 @@ class Babble_UnitTestCase extends WP_UnitTestCase {
 
 		update_option( 'babble-languages', $option );
 
-		$bbl_languages->initiate();
+		Babble::get( 'languages' )->initiate();
 
 	}
 

--- a/tests/test-jobs.php
+++ b/tests/test-jobs.php
@@ -7,7 +7,7 @@ class Test_Jobs extends Babble_UnitTestCase {
 		parent::setUp();
 	}
 	public function test_create_post_jobs() {
-		global $bbl_jobs;
+		$bbl_jobs = Babble::get( 'jobs' );
 		$post_id = $this->factory->post->create();
 
 		$jobs = $bbl_jobs->create_post_jobs( $post_id, array( 'fr_FR' ) );
@@ -20,7 +20,7 @@ class Test_Jobs extends Babble_UnitTestCase {
 
 	public function test_get_object_jobs_returns_none() {
 
-		global $bbl_jobs;
+		$bbl_jobs = Babble::get( 'jobs' );
 		$post_id = $this->factory->post->create();
 		$jobs = $bbl_jobs->get_object_jobs( $post_id, 'post', 'post', array( 'new' ) );
 
@@ -29,7 +29,7 @@ class Test_Jobs extends Babble_UnitTestCase {
 
 	public function test_get_object_jobs_new() {
 
-		global $bbl_jobs;
+		$bbl_jobs = Babble::get( 'jobs' );
 		$post_id = $this->factory->post->create();
 		$jobs    = $bbl_jobs->create_post_jobs( $post_id, array( 'fr_FR' ) );
 		$job_id  = $jobs[0];
@@ -47,7 +47,7 @@ class Test_Jobs extends Babble_UnitTestCase {
 	}
 
 	public function test_get_object_jobs_after_deleting_job() {
-		global $bbl_jobs;
+		$bbl_jobs = Babble::get( 'jobs' );
 		$post_id = $this->factory->post->create();
 		$jobs    = $bbl_jobs->create_post_jobs( $post_id, array( 'fr_FR' ) );
 		$job_id  = $jobs[0];
@@ -66,7 +66,7 @@ class Test_Jobs extends Babble_UnitTestCase {
 	}
 
 	public function test_get_object_jobs_after_creating_job() {
-		global $bbl_jobs;
+		$bbl_jobs = Babble::get( 'jobs' );
 		$post_id = $this->factory->post->create();
 		$jobs    = $bbl_jobs->create_post_jobs( $post_id, array( 'fr_FR' ) );
 		$job_id  = $jobs[0];

--- a/translation-group-tool.php
+++ b/translation-group-tool.php
@@ -158,8 +158,7 @@ class BabbleTranslationGroupTool extends Babble_Plugin {
 			return;
 		}
 
-		global $bbl_post_public;
-		$bbl_post_public->set_transid( $post, $transid );
+		Babble::get( 'post_public' )->set_transid( $post, $transid );
 	}
 
 	/**


### PR DESCRIPTION
See #220.

Back-compat globals remain inside `babble.php` for now. These should be moved into a separate sub-plugin.

This branch will probably need re-doing once everything else is merged into develop.
