### PR TITLE
Reduce dependency on Babble_Plugin class

### DIFF
--- a/babble.php
+++ b/babble.php
@@ -96,6 +96,11 @@ final class Babble {
 
 }
 
+function babble_init() {
+	load_plugin_textdomain( 'babble', false, dirname( plugin_basename( __FILE__ ) ) . '/locale' );
+}
+add_action( 'init', 'babble_init' );
+
 // Registry
 
 Babble::set( 'log',                new Babble_Log );

--- a/class-admin-bar.php
+++ b/class-admin-bar.php
@@ -6,10 +6,9 @@
  * @package Babble
  * @since 0.2
  */
-class Babble_Admin_bar extends Babble_Plugin {
+class Babble_Admin_bar {
 
 	function __construct() {
-		$this->setup( 'babble-switcher-menu', 'plugin' );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 100 );
 	}
 

--- a/class-comment.php
+++ b/class-comment.php
@@ -6,11 +6,9 @@
  * @package Babble
  * @since 0.1
  */
-class Babble_Comment extends Babble_Plugin {
+class Babble_Comment {
 
 	public function __construct() {
-		$this->setup( 'babble-comment', 'plugin' );
-
 		add_filter( 'comments_template_args', array( $this, 'comments_template_args' ) );
 		add_filter( 'preprocess_comment', array( $this, 'preprocess_comment' ) );
 		add_filter( 'get_comments_number', array( $this, 'get_comments_number' ), 10, 2 );

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -172,13 +172,13 @@ class Babble_Plugin {
 		$errors = $this->get_option( 'admin_errors' );
 		if ( $errors ) {
 			foreach ( $errors as $error ) {
-				$this->render_admin_error( $error );
+				self::render_admin_error( $error );
 				$this->delete_option( 'admin_errors' );
 			}
 		}
 		if ( $notices ) {
 			foreach ( $notices as $notice ) {
-				$this->render_admin_notice( $notice );
+				self::render_admin_notice( $notice );
 				$this->delete_option( 'admin_notices' );
 			}
 		}
@@ -191,7 +191,7 @@ class Babble_Plugin {
 	 * @return void
 	 * @author Simon Wheatley
 	 **/
-	protected function render_admin_notice( $notice ) {
+	protected static function render_admin_notice( $notice ) {
 		echo "<div class='updated'><p>" . esc_html( $notice ) . "</p></div>";
 	}
 
@@ -202,7 +202,7 @@ class Babble_Plugin {
 	 * @return void
 	 * @author Simon Wheatley
 	 **/
-	protected function render_admin_error( $error ) {
+	protected static function render_admin_error( $error ) {
 		echo "<div class='error'><p>" . esc_html( $error ) . "</p></div>";
 	}
 

--- a/class-post-public.php
+++ b/class-post-public.php
@@ -6,7 +6,7 @@
  * @package Babble
  * @since 0.1
  */
-class Babble_Post_Public extends Babble_Plugin {
+class Babble_Post_Public {
 
 	/**
 	 * A simple flag to stop infinite recursion when syncing
@@ -87,8 +87,6 @@ class Babble_Post_Public extends Babble_Plugin {
 	protected $translated_front_page_id = 0;
 
 	public function __construct() {
-		$this->setup( 'babble-post-public', 'plugin' );
-
 		add_action( 'added_post_meta', array( $this, 'added_post_meta' ), 10, 4 );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'clean_post_cache', array( $this, 'clean_post_cache' ) );
@@ -175,7 +173,7 @@ class Babble_Post_Public extends Babble_Plugin {
 			'is_default_lang' => (bool) ( bbl_get_current_lang_code() == bbl_get_default_lang_code() ),
 			'is_bbl_post_type' => (bool) ( 0 === strpos( $post_type, 'bbl_' ) ),
 		);
-		wp_enqueue_script( 'post-public-admin', $this->url( 'js/post-public-admin.js' ), array( 'jquery' ), filemtime( $this->dir( 'js/post-public-admin.js' ) ) );
+		wp_enqueue_script( 'post-public-admin', plugins_url( 'js/post-public-admin.js', __FILE__ ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) . '/js/post-public-admin.js' ) );
 		wp_localize_script( 'post-public-admin', 'bbl_post_public', $data );
 	}
 

--- a/class-taxonomy.php
+++ b/class-taxonomy.php
@@ -6,7 +6,7 @@
  * @package Babble
  * @since Alpha 1.2
  */
-class Babble_Taxonomies extends Babble_Plugin {
+class Babble_Taxonomies {
 	
 	/**
 	 * A simple flag to stop infinite recursion in various places.
@@ -43,7 +43,6 @@ class Babble_Taxonomies extends Babble_Plugin {
 	 * @return void
 	 **/
 	public function __construct() {
-		$this->setup( 'babble-taxonomy', 'plugin' );
 		add_action( 'bbl_created_new_shadow_post',      array( $this, 'created_new_shadow_post' ), 10, 2 );
 		add_action( 'bbl_registered_shadow_post_types', array( $this, 'registered_shadow_post_types' ) );
 		add_action( 'init',                             array( $this, 'init_early' ), 0 );

--- a/class-translator.php
+++ b/class-translator.php
@@ -5,7 +5,7 @@
  * @package Babble
  * @since 1.4
  */
-class Babble_Translator extends Babble_Plugin {
+class Babble_Translator {
 
 	/**
 	 * A version number used for cachebusting, rewrite rule
@@ -16,8 +16,6 @@ class Babble_Translator extends Babble_Plugin {
 	protected $version;
 
     public function __construct() {
-        $this->setup( 'babble-translator', 'plugin' );
-
         add_action( 'admin_init', array( $this, 'maybe_upgrade' ) );
 
 		$this->version = 1;

--- a/translation-group-tool.php
+++ b/translation-group-tool.php
@@ -125,7 +125,7 @@ class BabbleTranslationGroupTool extends Babble_Plugin {
 			return;
 		if ( $default_lang_post = bbl_get_post_in_lang( $post, bbl_get_default_lang_code() ) )
 			return;
-		$this->add_meta_box( 'bbl_reconnect', 'Reconnect Translation', 'metabox_reconnect', $post->post_type, 'side' );
+		add_meta_box( 'bbl_reconnect', 'Reconnect Translation', array( $this, 'metabox_reconnect' ), $post->post_type, 'side' );
 	}
 
 	/**


### PR DESCRIPTION
See #222.

Blocked by #312.

This greatly simplifies and reduces the dependency on the `Babble_Plugin` class, but doesn't remove it entirely. `Babble_Jobs`, `Babble_Languages`, `Babble_Switcher_Interface`, and `BabbleTranslationGroupTool` use its `render_admin()` and `get_option()` methods.

If I have time later today I'll revisit this and see about converting `Babble_Plugin` to a static class.
