### PR TITLE
Implement a Behat test which covers leaving a comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .idea
 vendor
 composer.lock
+bin

--- a/class-locale.php
+++ b/class-locale.php
@@ -305,11 +305,14 @@ class Babble_Locale {
 	/**
 	 * Hooks the WP query_vars filter to add the home_url filter.
 	 *
+	 * We also add the home_url filter at the start of the request
+	 * so the correct URL is set for all subsequent permalink / URL building
+	 * based off the current lagnuage.
+	 *
 	 * @param array $query_vars An array of the public query vars 
 	 * @return array An array of the public query vars
 	 **/
 	public function query_vars( array $query_vars ) {
-		# @TODO why is this here?
 		add_filter( 'home_url', array( $this, 'home_url' ), null, 2 );
 		return array_merge( $query_vars, array( 'lang', 'lang_url_prefix' ) );
 	}
@@ -318,10 +321,12 @@ class Babble_Locale {
 	 * Hooks the WP pre_comment_on_post action to add the 
 	 * home_url filter.
 	 *
+	 * When a user comments on a post, they should be redirected to
+	 * the language that their comment is in.
+	 *
 	 * @return void
 	 **/
 	public function pre_comment_on_post() {
-		# @TODO why is this here?
 		add_filter( 'home_url', array( $this, 'home_url' ), null, 2 );
 	}
 

--- a/features/comments.feature
+++ b/features/comments.feature
@@ -1,0 +1,21 @@
+Feature: Adding Comments
+	As a site visitor
+	In order to leave a comment
+	I need to ensure that commenting works as expected
+
+	Background:
+		Given I have a WordPress installation
+			| name      | email                     | username      | password |
+			| WordPress | administrator@example.com | administrator | password |
+		And there are plugins
+			| plugin            | status  |
+			| babble/babble.php | enabled |
+		And I am logged in as "administrator" with password "password"
+		And I go to "/wp-admin/"
+
+	Scenario: Redirection after leaving a comment
+		When I go to "/en/?p=1"
+		Then I should see "Leave a Reply"
+		When I fill in "comment" with "Here is my comment"
+		And I press "submit"
+		Then I should see "Here is my comment"

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,17 +5,14 @@
 1. Clone this git repository on your local machine.
 2. Install [Composer](https://getcomposer.org/) if you don't already have it.
 3. Run `composer install` to fetch all the dependencies.
-4. Install the test environment by executing:
+4. Install the Behat test environment by executing: `./bin/install.sh`
+5. Install the PHPUnit test environment by executing: `./bin/install-wp-tests.sh <db-name> <db-user> <db-pass>`
 
-        ./bin/install-wp-tests.sh <db-name> <db-user> <db-pass>
-
-  Ensure you use a separate test database (eg. `wp_tests`) because, just like the WordPress test suite, the database will be wiped clean with every test run.
+*Ensure you use a separate test database (eg. `wp_tests`) because, just like the WordPress test suite, the database will be wiped clean with every test run.*
 
 ## Running the unit tests
 
-To run the unit tests, just execute:
-
-    ./vendor/bin/phpunit
+To run the unit tests, just execute: `./vendor/bin/phpunit`
 
 ## Running the acceptance tests
 
@@ -23,10 +20,6 @@ Babble uses [Behat](http://behat.org) for acceptance testing. This requires a we
 
 First, edit `behat.yml` and change the database connection `db`, `username`, and `password` fields in the `default` block as appropriate.
 
-Start PHP's built-in web server by executing the following:
+Start PHP's built-in web server by executing the following: `php -S localhost:8000 -t vendor/wordpress -d disable_functions=mail &`
 
-    php -S localhost:8000 -t vendor/wordpress -d disable_functions=mail &
-
-To run the tests, execute the following:
-
-    ./bin/behat
+To run the tests, execute the following: `./bin/behat`


### PR DESCRIPTION
See #235.

Our existing unit tests cover the need for the `home_url` filter which is added in `Babble_Locale::query_vars()`.

This new Behat test covers the need for the `home_url` filter which is added in `Babble_Locale::pre_comment_on_post()`. The test ensures the redirect after the comment is posted is correct (if it's not, the comment isn't shown and the test fails).
