### PR TITLE
Use standard Goutte, fixes #328

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,6 @@
             "email": "hello@codeforthepeople.com"
         }
     ],
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/humanmade/Goutte.git"
-		}
-	],
     "require": {
         "composer/installers": "~1.0"
     },


### PR DESCRIPTION
Remove the repository definition for the HumanMade Goutte
