### PR TITLE
Fix #332 PHPUnit babble testcase fatal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
     # previous stable:
-    - WP_VERSION=4.2 WP_MULTISITE=0
-    - WP_VERSION=4.2 WP_MULTISITE=1
+    - WP_VERSION=4.2.5 WP_MULTISITE=0
+    - WP_VERSION=4.2.5 WP_MULTISITE=1
     # earliest supported:
-    - WP_VERSION=4.0 WP_MULTISITE=0
-    - WP_VERSION=4.0 WP_MULTISITE=1
+    - WP_VERSION=4.0.8 WP_MULTISITE=0
+    - WP_VERSION=4.0.8 WP_MULTISITE=1
 
 install:
     - bash bin/install.sh

--- a/tests/babble-compat.php
+++ b/tests/babble-compat.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Because we are using the WordPress tests from trunk, we may occasionally
+ * find functions are called which are not included in the version of
+ * WordPress which we are testing Babble against. This file conditionally
+ * defines these functions so that the tests will not fatal.
+ *
+ * A function can be removed from this file once the minimum version we
+ * test against is greater than the `@since` of the function.
+ *
+ * The minimum version we test against is defined in `/.travis.yml`, in the
+ * `env:` section.
+ */

--- a/tests/babble-compat.php
+++ b/tests/babble-compat.php
@@ -12,3 +12,22 @@
  * The minimum version we test against is defined in `/.travis.yml`, in the
  * `env:` section.
  */
+
+if ( ! function_exists( 'is_post_type_viewable' ) ) :
+
+/**
+ * Determines whether a post type is considered "viewable".
+ *
+ * For built-in post types such as posts and pages, the 'public' value will be evaluated.
+ * For all others, the 'publicly_queryable' value will be used.
+ *
+ * @since 4.4.0
+ *
+ * @param object $post_type_object Post type object.
+ * @return bool Whether the post type should be considered viewable.
+ */
+function is_post_type_viewable( $post_type_object ) {
+	return $post_type_object->publicly_queryable || ( $post_type_object->_builtin && $post_type_object->public );
+}
+
+endif; // is_post_type_viewable

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,4 +14,5 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
 
+require dirname( __FILE__ ) . '/babble-compat.php';
 require dirname( __FILE__ ) . '/babble-testcase.php';


### PR DESCRIPTION
This branch adds the missing `is_post_type_viewable`, introduced in trunk/4.4.0, so that we can continue using Trunk PHPUnit tests for Babble.
