### PR TITLE
Fix #339 wp_installing undefined

### DIFF
--- a/tests/babble-compat.php
+++ b/tests/babble-compat.php
@@ -31,3 +31,39 @@ function is_post_type_viewable( $post_type_object ) {
 }
 
 endif; // is_post_type_viewable
+
+
+if ( ! function_exists( 'wp_installing' ) ) :
+
+/**
+ * Check or set whether WordPress is in "installation" mode.
+ *
+ * If the `WP_INSTALLING` constant is defined during the bootstrap, `wp_installing()` will default to `true`.
+ *
+ * @since 4.4.0
+ *
+ * @staticvar bool $installing
+ *
+ * @param bool $is_installing Optional. True to set WP into Installing mode, false to turn Installing mode off.
+ *                            Omit this parameter if you only want to fetch the current status.
+ * @return bool True if WP is installing, otherwise false. When a `$is_installing` is passed, the function will
+ *              report whether WP was in installing mode prior to the change to `$is_installing`.
+ */
+function wp_installing( $is_installing = null ) {
+	static $installing = null;
+
+	// Support for the `WP_INSTALLING` constant, defined before WP is loaded.
+	if ( is_null( $installing ) ) {
+		$installing = defined( 'WP_INSTALLING' ) && WP_INSTALLING;
+	}
+
+	if ( ! is_null( $is_installing ) ) {
+		$old_installing = $installing;
+		$installing = $is_installing;
+		return (bool) $old_installing;
+	}
+
+	return (bool) $installing;
+}
+
+endif; // wp_installing


### PR DESCRIPTION
Add copy of `wp_installing` function during testing for compatability with WP versions which don't have it.
