### PR TITLE
Remove check for bbl_is_default_lang

### DIFF
--- a/class-post-public.php
+++ b/class-post-public.php
@@ -903,9 +903,6 @@ class Babble_Post_Public extends Babble_Plugin {
 	 * @return Path to a template file
 	 **/
 	public function single_template( $template ) {
-		if( bbl_is_default_lang() )
-			return $template;
-
 		// Deal with the language front pages and custom page templates
 		$post = get_post( get_the_ID() );
 		if ( 'page' == get_option('show_on_front') ) {


### PR DESCRIPTION
When using a page that employs a custom template, single.php (index.php) ends up being used for the default language variant instead of the custom template.
